### PR TITLE
1.6.0: re-exports, session ndebits (k1), CI compat suite

### DIFF
--- a/.github/workflows/nostr-tools-poll.yml
+++ b/.github/workflows/nostr-tools-poll.yml
@@ -30,20 +30,30 @@ jobs:
         with:
           node-version: '22'
 
-      - id: cmp
-        name: Compare registry vs pin
+      - id: pinned
+        name: Read pinned nostr-tools version
+        run: |
+          PINNED=$(node -p "require('./package.json').dependencies['nostr-tools']")
+          PINNED=${PINNED#=}
+          echo "pinned=$PINNED" >> "$GITHUB_OUTPUT"
+
+      - id: candidate
+        name: Resolve candidate version
         env:
           FORCED_VERSION: ${{ inputs.nostr_tools_version }}
         run: |
-          set -euo pipefail
-          PINNED=$(node -p "require('./package.json').dependencies['nostr-tools']")
-          # Strip any semver range prefix if present (we pin exact)
-          PINNED=${PINNED#=}
           if [ -n "$FORCED_VERSION" ]; then
-            CANDIDATE="$FORCED_VERSION"
+            echo "candidate=$FORCED_VERSION" >> "$GITHUB_OUTPUT"
           else
-            CANDIDATE=$(npm view nostr-tools version)
+            echo "candidate=$(npm view nostr-tools version)" >> "$GITHUB_OUTPUT"
           fi
+
+      - id: cmp
+        name: Compare registry vs pin
+        env:
+          PINNED: ${{ steps.pinned.outputs.pinned }}
+          CANDIDATE: ${{ steps.candidate.outputs.candidate }}
+        run: |
           echo "pinned=$PINNED" >> "$GITHUB_OUTPUT"
           echo "candidate=$CANDIDATE" >> "$GITHUB_OUTPUT"
           if [ "$CANDIDATE" = "$PINNED" ]; then
@@ -62,10 +72,19 @@ jobs:
       nostr_tools_version: ${{ needs.compare.outputs.candidate }}
       run_relay: true
 
+  # always() is required: without it, a failed test-candidate skips this job and
+  # we never open the tracking issue. The newer==true gate still early-exits when pin is current.
   conclude:
     needs: [compare, test-candidate]
     if: always() && needs.compare.outputs.newer == 'true'
     runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      CANDIDATE: ${{ needs.compare.outputs.candidate }}
+      PINNED: ${{ needs.compare.outputs.pinned }}
+      BRANCH: chore/bump-nostr-tools-${{ needs.compare.outputs.candidate }}
+      TITLE: chore: bump nostr-tools to ${{ needs.compare.outputs.candidate }}
+      ISSUE_TITLE: nostr-tools@${{ needs.compare.outputs.candidate }} fails ClinkSDK compat
     steps:
       - uses: actions/checkout@v4
 
@@ -73,59 +92,76 @@ jobs:
         with:
           node-version: '22'
 
-      - name: Open bump PR or tracking issue
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CANDIDATE: ${{ needs.compare.outputs.candidate }}
-          PINNED: ${{ needs.compare.outputs.pinned }}
-          TEST_RESULT: ${{ needs.test-candidate.result }}
+      # --- green path: bump PR ---
+      - name: Configure git identity
+        if: needs.test-candidate.result == 'success'
         run: |
-          set -euo pipefail
-          BRANCH="chore/bump-nostr-tools-${CANDIDATE}"
-          TITLE="chore: bump nostr-tools to ${CANDIDATE}"
-          ISSUE_TITLE="nostr-tools@${CANDIDATE} fails ClinkSDK compat"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
 
-          if [ "$TEST_RESULT" = "success" ]; then
-            git config user.name "github-actions[bot]"
-            git config user.email "github-actions[bot]@users.noreply.github.com"
+      - name: Checkout bump branch from main
+        if: needs.test-candidate.result == 'success'
+        run: |
+          git fetch origin main
+          git checkout -B "$BRANCH" origin/main
 
-            # Refresh branch from main
-            git fetch origin main
-            git checkout -B "$BRANCH" origin/main
+      - name: Install candidate nostr-tools
+        if: needs.test-candidate.result == 'success'
+        run: npm install "nostr-tools@${CANDIDATE}" --save-exact
 
-            npm install "nostr-tools@${CANDIDATE}" --save-exact
-            git add package.json package-lock.json
-            if git diff --cached --quiet; then
-              echo "no changes to commit"
-            else
-              git commit -m "$TITLE"
-              git push -u origin "$BRANCH" --force-with-lease
-            fi
-
-            if gh pr list --head "$BRANCH" --json number --jq 'length' | grep -q '^0$'; then
-              gh pr create --title "$TITLE" --body "Automated bump after green compat suite against \`nostr-tools@${CANDIDATE}\` (was \`${PINNED}\`)."
-            else
-              echo "PR already open for $BRANCH"
-            fi
-
-            # Close tracking issue if present
-            EXISTING=$(gh issue list --search "$ISSUE_TITLE in:title" --state open --json number --jq '.[0].number // empty')
-            if [ -n "$EXISTING" ]; then
-              gh issue close "$EXISTING" --comment "Compat suite passed for nostr-tools@${CANDIDATE}; bump PR opened/updated."
-            fi
+      - name: Commit and push bump
+        if: needs.test-candidate.result == 'success'
+        run: |
+          git add package.json package-lock.json
+          if git diff --cached --quiet; then
+            echo "no changes to commit"
           else
-            BODY=$(cat <<EOF
+            git commit -m "$TITLE"
+            git push -u origin "$BRANCH" --force-with-lease
+          fi
+
+      - name: Open bump PR if missing
+        if: needs.test-candidate.result == 'success'
+        run: |
+          if gh pr list --head "$BRANCH" --json number --jq 'length' | grep -q '^0$'; then
+            gh pr create --title "$TITLE" --body "Automated bump after green compat suite against \`nostr-tools@${CANDIDATE}\` (was \`${PINNED}\`)."
+          else
+            echo "PR already open for $BRANCH"
+          fi
+
+      - name: Close tracking issue if present
+        if: needs.test-candidate.result == 'success'
+        run: |
+          EXISTING=$(gh issue list --search "$ISSUE_TITLE in:title" --state open --json number --jq '.[0].number // empty')
+          if [ -n "$EXISTING" ]; then
+            gh issue close "$EXISTING" --comment "Compat suite passed for nostr-tools@${CANDIDATE}; bump PR opened/updated."
+          else
+            echo "no open tracking issue"
+          fi
+
+      # --- red path: tracking issue ---
+      - name: Open or update tracking issue
+        if: needs.test-candidate.result != 'success'
+        env:
+          TEST_RESULT: ${{ needs.test-candidate.result }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          BODY=$(cat <<EOF
           Automated poll found \`nostr-tools@${CANDIDATE}\` (pin \`${PINNED}\`) but the ClinkSDK compat suite failed (\`test-candidate\` result: \`${TEST_RESULT}\`).
 
-          Inspect the [poll workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}).
+          Inspect the [poll workflow run](${RUN_URL}).
           Do not bump until green.
           EOF
           )
-            EXISTING=$(gh issue list --search "$ISSUE_TITLE in:title" --state open --json number --jq '.[0].number // empty')
-            if [ -n "$EXISTING" ]; then
-              gh issue comment "$EXISTING" --body "$BODY"
-            else
-              gh issue create --title "$ISSUE_TITLE" --body "$BODY"
-            fi
-            exit 1
+          EXISTING=$(gh issue list --search "$ISSUE_TITLE in:title" --state open --json number --jq '.[0].number // empty')
+          if [ -n "$EXISTING" ]; then
+            gh issue comment "$EXISTING" --body "$BODY"
+          else
+            gh issue create --title "$ISSUE_TITLE" --body "$BODY"
           fi
+
+      - name: Fail job when compat suite failed
+        if: needs.test-candidate.result != 'success'
+        run: |
+          echo "test-candidate result: ${{ needs.test-candidate.result }}"
+          exit 1

--- a/.github/workflows/nostr-tools-poll.yml
+++ b/.github/workflows/nostr-tools-poll.yml
@@ -2,8 +2,8 @@ name: nostr-tools poll
 
 on:
   schedule:
-    # Daily UTC — early-exits when registry version matches pin
-    - cron: '17 6 * * *'
+    # Weekly UTC (Monday) — early-exits when registry version matches pin
+    - cron: '17 6 * * 1'
   workflow_dispatch:
     inputs:
       nostr_tools_version:

--- a/.github/workflows/nostr-tools-poll.yml
+++ b/.github/workflows/nostr-tools-poll.yml
@@ -83,8 +83,8 @@ jobs:
       CANDIDATE: ${{ needs.compare.outputs.candidate }}
       PINNED: ${{ needs.compare.outputs.pinned }}
       BRANCH: chore/bump-nostr-tools-${{ needs.compare.outputs.candidate }}
-      TITLE: chore: bump nostr-tools to ${{ needs.compare.outputs.candidate }}
-      ISSUE_TITLE: nostr-tools@${{ needs.compare.outputs.candidate }} fails ClinkSDK compat
+      TITLE: "chore: bump nostr-tools to ${{ needs.compare.outputs.candidate }}"
+      ISSUE_TITLE: "nostr-tools@${{ needs.compare.outputs.candidate }} fails ClinkSDK compat"
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/nostr-tools-poll.yml
+++ b/.github/workflows/nostr-tools-poll.yml
@@ -1,0 +1,131 @@
+name: nostr-tools poll
+
+on:
+  schedule:
+    # Daily UTC — early-exits when registry version matches pin
+    - cron: '17 6 * * *'
+  workflow_dispatch:
+    inputs:
+      nostr_tools_version:
+        description: Force a specific nostr-tools version (skip compare)
+        required: false
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  compare:
+    runs-on: ubuntu-latest
+    outputs:
+      newer: ${{ steps.cmp.outputs.newer }}
+      candidate: ${{ steps.cmp.outputs.candidate }}
+      pinned: ${{ steps.cmp.outputs.pinned }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - id: cmp
+        name: Compare registry vs pin
+        env:
+          FORCED_VERSION: ${{ inputs.nostr_tools_version }}
+        run: |
+          set -euo pipefail
+          PINNED=$(node -p "require('./package.json').dependencies['nostr-tools']")
+          # Strip any semver range prefix if present (we pin exact)
+          PINNED=${PINNED#=}
+          if [ -n "$FORCED_VERSION" ]; then
+            CANDIDATE="$FORCED_VERSION"
+          else
+            CANDIDATE=$(npm view nostr-tools version)
+          fi
+          echo "pinned=$PINNED" >> "$GITHUB_OUTPUT"
+          echo "candidate=$CANDIDATE" >> "$GITHUB_OUTPUT"
+          if [ "$CANDIDATE" = "$PINNED" ]; then
+            echo "newer=false" >> "$GITHUB_OUTPUT"
+            echo "nostr-tools@$PINNED is current; exiting early"
+          else
+            echo "newer=true" >> "$GITHUB_OUTPUT"
+            echo "registry has nostr-tools@$CANDIDATE (pin $PINNED)"
+          fi
+
+  test-candidate:
+    needs: compare
+    if: needs.compare.outputs.newer == 'true'
+    uses: ./.github/workflows/test.yml
+    with:
+      nostr_tools_version: ${{ needs.compare.outputs.candidate }}
+      run_relay: true
+
+  conclude:
+    needs: [compare, test-candidate]
+    if: always() && needs.compare.outputs.newer == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Open bump PR or tracking issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CANDIDATE: ${{ needs.compare.outputs.candidate }}
+          PINNED: ${{ needs.compare.outputs.pinned }}
+          TEST_RESULT: ${{ needs.test-candidate.result }}
+        run: |
+          set -euo pipefail
+          BRANCH="chore/bump-nostr-tools-${CANDIDATE}"
+          TITLE="chore: bump nostr-tools to ${CANDIDATE}"
+          ISSUE_TITLE="nostr-tools@${CANDIDATE} fails ClinkSDK compat"
+
+          if [ "$TEST_RESULT" = "success" ]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+
+            # Refresh branch from main
+            git fetch origin main
+            git checkout -B "$BRANCH" origin/main
+
+            npm install "nostr-tools@${CANDIDATE}" --save-exact
+            git add package.json package-lock.json
+            if git diff --cached --quiet; then
+              echo "no changes to commit"
+            else
+              git commit -m "$TITLE"
+              git push -u origin "$BRANCH" --force-with-lease
+            fi
+
+            if gh pr list --head "$BRANCH" --json number --jq 'length' | grep -q '^0$'; then
+              gh pr create --title "$TITLE" --body "Automated bump after green compat suite against \`nostr-tools@${CANDIDATE}\` (was \`${PINNED}\`)."
+            else
+              echo "PR already open for $BRANCH"
+            fi
+
+            # Close tracking issue if present
+            EXISTING=$(gh issue list --search "$ISSUE_TITLE in:title" --state open --json number --jq '.[0].number // empty')
+            if [ -n "$EXISTING" ]; then
+              gh issue close "$EXISTING" --comment "Compat suite passed for nostr-tools@${CANDIDATE}; bump PR opened/updated."
+            fi
+          else
+            BODY=$(cat <<EOF
+          Automated poll found \`nostr-tools@${CANDIDATE}\` (pin \`${PINNED}\`) but the ClinkSDK compat suite failed (\`test-candidate\` result: \`${TEST_RESULT}\`).
+
+          Inspect the [poll workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}).
+          Do not bump until green.
+          EOF
+          )
+            EXISTING=$(gh issue list --search "$ISSUE_TITLE in:title" --state open --json number --jq '.[0].number // empty')
+            if [ -n "$EXISTING" ]; then
+              gh issue comment "$EXISTING" --body "$BODY"
+            else
+              gh issue create --title "$ISSUE_TITLE" --body "$BODY"
+            fi
+            exit 1
+          fi

--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -1,18 +1,26 @@
 name: Publish to npm
 
+# Gate releases on a green CI run for main (also what the README badge reflects).
 on:
-  push:
-    branches:
-      - main
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+    branches: [main]
 
 jobs:
   publish:
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push'
     runs-on: ubuntu-latest
     permissions:
       contents: write
       id-token: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Publish the commit CI actually validated, not whatever main is now.
+          ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Use Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,128 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      nostr_tools_version:
+        description: Optional nostr-tools version override for current tree
+        required: false
+        type: string
+      prior_sdk_version:
+        description: Optional prior @shocknet/clink-sdk version (default npm view latest)
+        required: false
+        type: string
+      run_relay:
+        description: Run strfry relay compat job
+        required: false
+        type: boolean
+        default: true
+      pr_number:
+        description: Optional PR number to checkout (refs/pull/N/merge)
+        required: false
+        type: string
+  workflow_call:
+    inputs:
+      nostr_tools_version:
+        description: Optional nostr-tools version override for current tree
+        required: false
+        type: string
+      prior_sdk_version:
+        description: Optional prior @shocknet/clink-sdk version
+        required: false
+        type: string
+      run_relay:
+        required: false
+        type: boolean
+        default: true
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ inputs.nostr_tools_version || 'pinned' }}
+  cancel-in-progress: true
+
+env:
+  NOSTR_TOOLS_VERSION: ${{ inputs.nostr_tools_version || '' }}
+  PRIOR_SDK_VERSION: ${{ inputs.prior_sdk_version || '' }}
+
+jobs:
+  unit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.pr_number && format('refs/pull/{0}/merge', inputs.pr_number) || github.ref }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+
+      - run: npm ci
+      - run: npm run prepack
+      - run: npm run test:unit
+
+  compat-offline:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.pr_number && format('refs/pull/{0}/merge', inputs.pr_number) || github.ref }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+
+      - run: npm ci
+      - run: npm run prepack
+      - name: Materialize trees + offline compat
+        run: npm run test:compat-offline
+
+  compat-relay:
+    # inputs.run_relay is unset for pull_request/push; toJSON avoids '' == false coercion
+    if: ${{ toJSON(inputs.run_relay) != 'false' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.pr_number && format('refs/pull/{0}/merge', inputs.pr_number) || github.ref }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+
+      - run: npm ci
+      - run: npm run prepack
+
+      - name: Start strfry
+        run: |
+          docker run -d --name strfry \
+            -p 7777:7777 \
+            -v "$PWD/test/compat/strfry.conf:/etc/strfry.conf:ro" \
+            dockurr/strfry:latest
+          docker ps
+
+      - name: Materialize current + prior trees
+        run: npm run test:setup-trees
+
+      - name: Wait for strfry
+        run: npm run test:wait-relay
+        env:
+          RELAY_URL: ws://127.0.0.1:7777
+          RELAY_WAIT_MS: '90000'
+
+      - name: Relay ping-pong
+        run: npm run test:compat-relay
+        env:
+          RELAY_URL: ws://127.0.0.1:7777
+          RECEIPT_DELAY_MS: '2000'
+
+      - name: strfry logs on failure
+        if: failure()
+        run: docker logs strfry || true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,11 +102,20 @@ jobs:
 
       - name: Start strfry
         run: |
+          # Named volume so LMDB can create /app/strfry-db (image may lack a writable dir)
+          docker volume create strfry-db
           docker run -d --name strfry \
             -p 7777:7777 \
             -v "$PWD/test/compat/strfry.conf:/etc/strfry.conf:ro" \
+            -v strfry-db:/app/strfry-db \
             dockurr/strfry:latest
           docker ps
+          # Fail fast if the container exited (e.g. mdb_env_open)
+          sleep 1
+          if [ "$(docker inspect -f '{{.State.Running}}' strfry)" != "true" ]; then
+            docker logs strfry || true
+            exit 1
+          fi
 
       - name: Materialize current + prior trees
         run: npm run test:setup-trees

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ small.mp4
 small2.mp4
 .npmrc
 .specstory
+test/fixtures/compat-trees

--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,7 @@
 tsconfig.json
 src
+test
+.github
 .env
 node_modules
 dist

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 - [API Reference](#api-reference)
   - [ClinkSDK](#clinksdk)
   - [Encoding/Decoding](#encodingdecoding)
+  - [Validators](#validators)
   - [Nostr Helpers (re-exported)](#nostr-helpers-re-exported)
   - [Types](#types)
 - [Troubleshooting & Language Porting](#troubleshooting--language-porting)
@@ -236,6 +237,13 @@ new ClinkSDK(settings: ClinkSettings, pool?: AbstractSimplePool)
 - `generateK1(): string` — 32-byte session identifier as lowercase hex (ndebit TLV `3`)
 - `validateK1(k1: unknown): string` — throws unless `k1` is 64 lowercase hex chars; returns it unchanged
 
+### Validators
+
+For validating inbound/outbound CLINK payloads (e.g. server-side request checks). Each throws on invalid input and returns the typed value on success:
+
+- `validateNofferData`, `validateNdebitData`, `validateK1`, `validateBudgetFrequency`
+- `validateNmanageRequest` and per-action helpers: `validateNmanageCreateOffer`, `validateNmanageUpdateOffer`, `validateNmanageDeleteOffer`, `validateNmanageGetOffer`, `validateNmanageListOffers`, `validateOfferFields`
+
 ### Debug
 - `setDebug(enabled: boolean)` — when `true`, logs relay subscribe/publish/response lifecycle to the console (default `false`)
 
@@ -256,7 +264,7 @@ Pinned by this package — import these from `@shocknet/clink-sdk`, not from a s
 | `UnsignedEvent` | type | Event shape before `finalizeEvent` |
 
 ### Types
-- **`NofferData`**: `{ offer: string, amount_sats?: number, description?: string, expires_in_seconds?: number, zap?: string, payer_data?: any }`
+- **`NofferData`**: `{ offer: string, amount_sats?: number, description?: string, expires_in_seconds?: number, zap?: string, payer_data?: Record<string, string> }`
 - **`NofferResponse`**: `{ bolt11: string } | { code: number, error: string, range?: { min: number, max: number } }`
 - **`NofferReceipt`**: `{ res: 'ok' }` - The receipt object sent when an invoice is paid
 - **`NdebitData`**: `{ pointer?: string, amount_sats?: number, bolt11?: string, frequency?: BudgetFrequency, k1?: string, description?: string }`

--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ const sdk = new ClinkSDK({
 
 // Request the service to pay an invoice
 const simplePaymentRequest = newNdebitPaymentRequest('<BOLT11_invoice_string>', 5000, 'my_pointer_id');
+// Optional: session k1 and/or description — newNdebitPaymentRequest(invoice, amount, pointer, k1?, description?)
 
 sdk.Ndebit(simplePaymentRequest).then(response => {
   if (response.res === 'ok') {
@@ -233,6 +234,10 @@ new ClinkSDK(settings: ClinkSettings, pool?: AbstractSimplePool)
 - `nmanageEncode(manage: ManagePointer): string`
 - `decodeBech32(nip19: string): DecodeResult`
 - `generateK1(): string` — 32-byte session identifier as lowercase hex (ndebit TLV `3`)
+- `validateK1(k1: unknown): string` — throws unless `k1` is 64 lowercase hex chars; returns it unchanged
+
+### Debug
+- `setDebug(enabled: boolean)` — when `true`, logs relay subscribe/publish/response lifecycle to the console (default `false`)
 
 ### Nostr helpers (re-exported)
 

--- a/README.md
+++ b/README.md
@@ -223,6 +223,8 @@ new ClinkSDK(settings: ClinkSettings, pool?: AbstractSimplePool)
 - `Nmanage(data: NmanageRequest, timeoutSeconds?: number)`
   - Sends a `kind: 21003` management request.
   - Returns a `Promise<NmanageResponse>` that resolves with the result of the management action.
+- `Stop()`
+  - Closes relay connections on the internal pool. Call when finished so the process can exit cleanly.
 
 
 ### Encoding/Decoding

--- a/README.md
+++ b/README.md
@@ -4,6 +4,26 @@
 
 ---
 
+## Table of Contents
+
+- [Overview](#overview)
+- [Features](#features)
+- [Installation](#installation)
+- [Usage](#usage)
+  - [1. Encoding/Decoding Offers and Debits](#1-encodingdecoding-offers-and-debits)
+  - [2. Sending a CLINK Offer Request (Lightning Invoice)](#2-sending-a-clink-offer-request-lightning-invoice)
+  - [3. Sending a CLINK Debit Request](#3-sending-a-clink-debit-request)
+- [API Reference](#api-reference)
+  - [ClinkSDK](#clinksdk)
+  - [Encoding/Decoding](#encodingdecoding)
+  - [Nostr Helpers (re-exported)](#nostr-helpers-re-exported)
+  - [Types](#types)
+- [Troubleshooting & Language Porting](#troubleshooting--language-porting)
+- [Protocol](#protocol)
+- [License](#license)
+
+---
+
 ## Overview
 
 `@shocknet/clink-sdk` provides a simple, robust interface for working with [CLINK](https://github.com/shocknet/CLINK/) (`noffer1...` and `ndebit1...`) on Nostr. It enables applications and wallets to create, encode, decode, send, and receive CLINK payment requests and authorizations using Nostr relays, with full support for NIP-44 encryption and the CLINK protocol.
@@ -31,6 +51,8 @@ npm install @shocknet/clink-sdk
 # or
 yarn add @shocknet/clink-sdk
 ```
+
+> ⚠️ **Important:** Do not install `nostr-tools` yourself. This SDK pins a compatible version; a second copy often causes decrypt failures and missed responses. Import helpers like `SimplePool`, `nip44`, and `finalizeEvent` from `@shocknet/clink-sdk`. See the [Troubleshooting Guide](docs/troubleshooting.md) for details.
 
 ---
 
@@ -154,7 +176,7 @@ sdk.Ndebit(budgetRequest).then(response => {
 new ClinkSDK(settings: ClinkSettings, pool?: AbstractSimplePool)
 ```
 - `settings`: `{ privateKey: Uint8Array, relays: string[], toPubKey: string, defaultTimeoutSeconds?: number }`
-- `pool`: Optional, pass a custom Nostr pool (defaults to `SimplePool` from nostr-tools).
+- `pool`: Optional custom Nostr pool (defaults to `SimplePool` from this package’s pinned `nostr-tools`). If you pass one, build it with `SimplePool` imported from `@shocknet/clink-sdk`.
 
 #### Methods
 - `Noffer(data: NofferData, onReceipt?: (receipt: NofferReceipt) => void, timeoutSeconds?: number)`
@@ -172,7 +194,24 @@ new ClinkSDK(settings: ClinkSettings, pool?: AbstractSimplePool)
 ### Encoding/Decoding
 - `nofferEncode(offer: OfferPointer): string`
 - `ndebitEncode(debit: DebitPointer): string`
+- `nmanageEncode(manage: ManagePointer): string`
 - `decodeBech32(nip19: string): DecodeResult`
+
+### Nostr helpers (re-exported)
+
+Pinned by this package — import these from `@shocknet/clink-sdk`, not from a separate `nostr-tools` install:
+
+| Export | Kind | Use |
+|--------|------|-----|
+| `SimplePool` | value | Default relay pool; use this if you pass a custom `pool` |
+| `getPublicKey` | value | Derive pubkey from secret key |
+| `generateSecretKey` | value | Create a new secret key |
+| `nip19` | value | Bech32 encode/decode (`npub` / `nsec` / …) |
+| `finalizeEvent` | value | Sign an unsigned event |
+| `nip44` | value | Encrypt/decrypt CLINK payloads (`encrypt`, `decrypt`, `getConversationKey`) |
+| `verifyEvent` | value | Verify event signatures (e.g. NIP-98) |
+| `AbstractSimplePool` | type | Type for a custom `pool` argument |
+| `UnsignedEvent` | type | Event shape before `finalizeEvent` |
 
 ### Types
 - **`NofferData`**: `{ offer: string, amount_sats?: number, description?: string, expires_in_seconds?: number, zap?: string, payer_data?: any }`
@@ -184,6 +223,19 @@ new ClinkSDK(settings: ClinkSettings, pool?: AbstractSimplePool)
 - **`DebitPointer`**: `{ pubkey: string, relay: string, pointer?: string }`
 - **`OfferPriceType`**: `enum { Fixed = 0, Variable = 1, Spontaneous = 2 }`
 - **`BudgetFrequency`**: `{ number: number, unit: 'day' | 'week' | 'month' }`
+- **`ClinkSettings`**: `{ privateKey: Uint8Array, relays: string[], toPubKey: string, defaultTimeoutSeconds?: number }`
+- **`AbstractSimplePool`**, **`UnsignedEvent`**: see Nostr helpers above
+
+---
+
+## Troubleshooting & Language Porting
+
+For detailed guidance on:
+- Resolving `nostr-tools` dependency conflicts
+- Diagnosing silent timeouts or "no response" issues
+- Porting the CLINK protocol and NIP-44 v2 encryption to other languages (C#, Go, etc.) with test vectors
+
+Please refer to our [Troubleshooting & Interoperability Guide](docs/troubleshooting.md).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,13 @@ sdk.Noffer(request, receiptCallback).then(response => {
 ### 3. Sending a CLINK Debit Request
 
 ```ts
-import { ClinkSDK, NdebitData, generateSecretKey } from '@shocknet/clink-sdk';
+import {
+  ClinkSDK,
+  generateSecretKey,
+  newNdebitPaymentRequest,
+  newNdebitFullAccessRequest,
+  newNdebitBudgetRequest,
+} from '@shocknet/clink-sdk';
 
 const sdk = new ClinkSDK({
   privateKey: generateSecretKey(),
@@ -128,7 +134,7 @@ const sdk = new ClinkSDK({
 });
 
 // Request the service to pay an invoice
-const simplePaymentRequest = newNdebitPaymentRequest('<BOLT11_invoice_string>', 5000, 'my_pointer_id')
+const simplePaymentRequest = newNdebitPaymentRequest('<BOLT11_invoice_string>', 5000, 'my_pointer_id');
 
 sdk.Ndebit(simplePaymentRequest).then(response => {
   if (response.res === 'ok') {
@@ -143,27 +149,26 @@ sdk.Ndebit(simplePaymentRequest).then(response => {
 });
 
 // Request whitelisting for future payment requests
-const fullAccessRequest = newNdebitFullAccessRequest('my_pointer_id')
+const fullAccessRequest = newNdebitFullAccessRequest('my_pointer_id');
 
 sdk.Ndebit(fullAccessRequest).then(response => {
   if (response.res === 'ok') {
-    console.log('Full access aproved:');
+    console.log('Full access approved:');
   } else if (response.res === 'GFY') {
     console.error('Full access request failed:', response.error);
   }
 });
 
 // Request a budget
-const budgetRequest = newNdebitBudgetRequest({ number: 1, unit: 'week' }, 1000, 'my_pointer_id')
+const budgetRequest = newNdebitBudgetRequest({ number: 1, unit: 'week' }, 1000, 'my_pointer_id');
 
 sdk.Ndebit(budgetRequest).then(response => {
   if (response.res === 'ok') {
-    console.log('Budget aproved:');
+    console.log('Budget approved:');
   } else if (response.res === 'GFY') {
     console.error('Budget request failed:', response.error);
   }
 });
-
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ yarn add @shocknet/clink-sdk
 ### 1. Encoding/Decoding Offers and Debits
 
 ```ts
-import { nofferEncode, ndebitEncode, decodeBech32, OfferPriceType } from '@shocknet/clink-sdk';
+import { nofferEncode, ndebitEncode, decodeBech32, OfferPriceType, generateK1 } from '@shocknet/clink-sdk';
 
 // Encode a CLINK Offer
 const noffer = nofferEncode({
@@ -78,6 +78,14 @@ const noffer = nofferEncode({
 const decoded = decodeBech32(noffer);
 console.log(decoded);
 // { type: 'noffer', data: { pubkey, relay, offer, priceType, price } }
+
+// Encode a session ndebit — k1 is TLV type 3
+const sessionNdebit = ndebitEncode({
+  pubkey: '<node_service_pubkey_hex>',
+  relay: 'wss://relay.example.com',
+  pointer: '<app_user_pointer>',
+  k1: generateK1(),
+});
 ```
 
 ### 2. Sending a CLINK Offer Request (Lightning Invoice)
@@ -123,12 +131,31 @@ sdk.Noffer(request, receiptCallback).then(response => {
 ```ts
 import {
   ClinkSDK,
+  decodeBech32,
   generateSecretKey,
   newNdebitPaymentRequest,
   newNdebitFullAccessRequest,
   newNdebitBudgetRequest,
 } from '@shocknet/clink-sdk';
 
+// Session flow: scan ndebit QR, pay with matching k1
+const scanned = decodeBech32('ndebit1...');
+if (scanned.type === 'ndebit') {
+  const sessionSdk = new ClinkSDK({
+    privateKey: generateSecretKey(),
+    relays: [scanned.data.relay],
+    toPubKey: scanned.data.pubkey,
+  });
+  const sessionPayment = newNdebitPaymentRequest(
+    '<BOLT11_invoice_string>',
+    5000,
+    scanned.data.pointer,
+    scanned.data.k1,
+  );
+  sessionSdk.Ndebit(sessionPayment).then(/* ... */);
+}
+
+// Authorization flow: static pointer
 const sdk = new ClinkSDK({
   privateKey: generateSecretKey(),
   relays: ['wss://relay.example.com'],
@@ -203,6 +230,7 @@ new ClinkSDK(settings: ClinkSettings, pool?: AbstractSimplePool)
 - `ndebitEncode(debit: DebitPointer): string`
 - `nmanageEncode(manage: ManagePointer): string`
 - `decodeBech32(nip19: string): DecodeResult`
+- `generateK1(): string` — 32-byte session identifier as lowercase hex (ndebit TLV `3`)
 
 ### Nostr helpers (re-exported)
 
@@ -224,10 +252,10 @@ Pinned by this package — import these from `@shocknet/clink-sdk`, not from a s
 - **`NofferData`**: `{ offer: string, amount_sats?: number, description?: string, expires_in_seconds?: number, zap?: string, payer_data?: any }`
 - **`NofferResponse`**: `{ bolt11: string } | { code: number, error: string, range?: { min: number, max: number } }`
 - **`NofferReceipt`**: `{ res: 'ok' }` - The receipt object sent when an invoice is paid
-- **`NdebitData`**: `{ pointer?: string, amount_sats?: number, bolt11?: string, frequency?: BudgetFrequency }`
+- **`NdebitData`**: `{ pointer?: string, amount_sats?: number, bolt11?: string, frequency?: BudgetFrequency, k1?: string, description?: string }`
 - **`NdebitResponse`**: `{ res: 'ok', preimage?: string } | { res: 'GFY', error: string, code: number }`
 - **`OfferPointer`**: `{ pubkey: string, relay: string, offer: string, priceType: OfferPriceType, price?: number }`
-- **`DebitPointer`**: `{ pubkey: string, relay: string, pointer?: string }`
+- **`DebitPointer`**: `{ pubkey: string, relay: string, pointer?: string, k1?: string }`
 - **`OfferPriceType`**: `enum { Fixed = 0, Variable = 1, Spontaneous = 2 }`
 - **`BudgetFrequency`**: `{ number: number, unit: 'day' | 'week' | 'month' }`
 - **`ClinkSettings`**: `{ privateKey: Uint8Array, relays: string[], toPubKey: string, defaultTimeoutSeconds?: number }`

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ npm install @shocknet/clink-sdk
 yarn add @shocknet/clink-sdk
 ```
 
-> ⚠️ **Important:** Do not install `nostr-tools` yourself. This SDK pins a compatible version; a second copy often causes decrypt failures and missed responses. Import helpers like `SimplePool`, `nip44`, and `finalizeEvent` from `@shocknet/clink-sdk`. See the [Troubleshooting Guide](docs/troubleshooting.md) for details.
+> ⚠️ **Important:** Do not install `nostr-tools` yourself. This SDK pins a compatible version; a second copy often causes decrypt failures and missed responses. Import helpers like `SimplePool`, `nip44`, and `finalizeEvent` from `@shocknet/clink-sdk`. Details: [Troubleshooting Guide](docs/troubleshooting.md).
 
 ---
 
@@ -230,12 +230,8 @@ Pinned by this package — import these from `@shocknet/clink-sdk`, not from a s
 
 ## Troubleshooting & Language Porting
 
-For detailed guidance on:
-- Resolving `nostr-tools` dependency conflicts
-- Diagnosing silent timeouts or "no response" issues
-- Porting the CLINK protocol and NIP-44 v2 encryption to other languages (C#, Go, etc.) with test vectors
-
-Please refer to our [Troubleshooting & Interoperability Guide](docs/troubleshooting.md).
+- `nostr-tools` conflicts, timeouts, and NIP-44 / NIP-19 ports: [docs/troubleshooting.md](docs/troubleshooting.md)
+- Interop vectors for language ports: [test-vectors/interop.json](test-vectors/interop.json)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # @shocknet/clink-sdk
 
+[![CI](https://github.com/shocknet/ClinkSDK/actions/workflows/test.yml/badge.svg?branch=main)](https://github.com/shocknet/ClinkSDK/actions/workflows/test.yml)
+
 **A TypeScript/JavaScript SDK for the CLINK protocol — Nostr-native static Lightning payment offers and debits.**
 
 ---

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,81 @@
+# Troubleshooting & Interoperability Guide
+
+This guide covers common integration issues, dependency conflicts, and language porting guidelines for the CLINK SDK.
+
+---
+
+## Table of Contents
+
+1. [Nostr-Tools Dependency Conflicts](#1-nostr-tools-dependency-conflicts)
+2. [Troubleshooting "No Response" / Timeouts](#2-troubleshooting-no-response--timeouts)
+3. [Porting to Other Languages (C#, Go, etc.)](#3-porting-to-other-languages-c-go-etc)
+
+---
+
+## 1. Nostr-Tools Dependency Conflicts
+
+**Do not install `nostr-tools` as a direct dependency in your application.**
+
+This SDK pins a compatible version. A second copy in your app’s dependency tree often causes silent timeouts — missed replies or payloads that won’t decrypt — even though the peer is responding correctly.
+
+### Why a second copy causes that
+When multiple versions of `nostr-tools` exist in your dependency tree:
+- **Separate pools:** A `SimplePool` from your copy and one from the SDK do not share connection state, so events can land on a socket your code isn’t listening on.
+- **NIP-44 drift:** Different builds of `nip44` can disagree on encrypt/decrypt, so replies arrive but never parse.
+
+### How to import Nostr helpers
+Import all required Nostr values and types directly from `@shocknet/clink-sdk` instead of `nostr-tools`:
+
+```ts
+import {
+  ClinkSDK,
+  SimplePool,
+  getPublicKey,
+  finalizeEvent,
+  nip44,
+  verifyEvent,
+  type AbstractSimplePool,
+  type UnsignedEvent,
+} from '@shocknet/clink-sdk';
+```
+
+---
+
+## 2. Troubleshooting "No Response" / Timeouts
+
+If your application sends a request (Offer, Debit, or Manage) but times out waiting for a response, it is almost always due to one of the following:
+
+### A. Wrong NIP-44 Encryption Implementation
+If you are communicating with a peer running a different implementation (e.g. a custom C# plugin or an older wallet), an encryption mismatch will cause incoming responses to be undecryptable. The SDK will silently ignore undecryptable events and eventually time out.
+- **Check:** Ensure both sides use NIP-44 v2 spec-compliant encryption. See the [Porting](#3-porting-to-other-languages-c-go-etc) section below for exact vector specifications.
+
+### B. Publish-Before-Subscribe Race Condition
+If you publish a request to a relay *before* setting up your subscription for the response, a fast responder (like a CLINK wallet) may publish its reply before your subscription is active.
+- **Check:** Always establish your subscription filter (listening for `#e` matching your request event ID) *before* sending the `EVENT` message to the relay. The `@shocknet/clink-sdk` handles this order of operations internally.
+
+### C. Leaking Subscriptions
+If you are managing your own relay subscriptions or connection loops, failing to close old subscriptions will leak resources and can degrade relay performance or cause connection limits to be hit.
+- **Check:** Ensure you call `close()` on the subscription handle (`SubCloser`) as soon as the primary response is received.
+
+---
+
+## 3. Porting to Other Languages (C#, Go, etc.)
+
+If you are writing a CLINK client or plugin in a language other than TypeScript/JavaScript, **do not implement NIP-44 or the CLINK TLV/Bech32 encoding from scratch without testing against the official vectors.**
+
+Refer to [`test-vectors/interop.json`](../test-vectors/interop.json) as the strict contract for interoperability.
+
+### Common Language Porting Footguns
+
+| Mistake | What went wrong | Symptom |
+|---------|-----------------|---------|
+| **Incorrect Conversation Key Salt** | Deriving the conversation key using `HMAC("nip44-v2", sharedX)` instead of `HKDF-Extract(salt="nip44-v2", IKM=sharedX)`. | Peer cannot decrypt your events; you cannot decrypt theirs. |
+| **Incorrect Message Keys Derivation** | Using a custom HKDF info string (like `"nip44-v2-keys"`) instead of a single `HKDF-Expand` with the 32-byte raw nonce as info. | Same as above. |
+| **2-Byte TLV Lengths** | Encoding or parsing TLV lengths as 2-byte big-endian integers. CLINK TLV uses **1-byte lengths** (`type (1) \| length (1) | value (length)`). | `noffer1` / `ndebit1` strings decode into garbage; routing/auth fails. |
+| **Swapped TLV Tags** | Swapping tag `0` (pubkey) and tag `1` (relay). Tag `0` must be the 32-byte raw public key; tag `1` must be the UTF-8 relay URL. | Bech32 strings fail to decode or route to the wrong relay. |
+| **Publish, then Subscribe** | Publishing the request event to the relay before sending the subscription request. | Intermittent timeouts, especially on fast relays or local networks. |
+
+### Recommended Porting Workflow
+1. **Assert Bech32/TLV Decodes:** Verify your decoder can parse the sample `noffer` and `ndebit` strings in `test-vectors/interop.json` and extract the exact fields.
+2. **Assert NIP-44 Key Derivation:** Verify that your ECDH shared-secret and HKDF key derivation matches the fixed conversation-key vector in `test-vectors/interop.json`.
+3. **Test E2E with a Relay:** Verify your client can communicate with a standard JS/TS client or wallet before deploying to production.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,30 +1,25 @@
 # Troubleshooting & Interoperability Guide
 
-This guide covers common integration issues, dependency conflicts, and language porting guidelines for the CLINK SDK.
-
 ---
 
 ## Table of Contents
 
-1. [Nostr-Tools Dependency Conflicts](#1-nostr-tools-dependency-conflicts)
-2. [Troubleshooting "No Response" / Timeouts](#2-troubleshooting-no-response--timeouts)
-3. [Porting to Other Languages (C#, Go, etc.)](#3-porting-to-other-languages-c-go-etc)
+1. [Nostr-tools dependency conflicts](#1-nostr-tools-dependency-conflicts)
+2. [Troubleshooting "no response" / timeouts](#2-troubleshooting-no-response--timeouts)
+3. [Porting to other languages](#3-porting-to-other-languages)
 
 ---
 
-## 1. Nostr-Tools Dependency Conflicts
+## 1. Nostr-tools dependency conflicts
 
-**Do not install `nostr-tools` as a direct dependency in your application.**
+**Do not install `nostr-tools` yourself.** This package pins a compatible version. Import helpers from `@shocknet/clink-sdk` instead.
 
-This SDK pins a compatible version. A second copy in your app’s dependency tree often causes silent timeouts — missed replies or payloads that won’t decrypt — even though the peer is responding correctly.
+A second copy in the dependency tree often causes missed replies or undecryptable payloads — the peer may be fine; your client never sees a usable response.
 
-### Why a second copy causes that
-When multiple versions of `nostr-tools` exist in your dependency tree:
-- **Separate pools:** A `SimplePool` from your copy and one from the SDK do not share connection state, so events can land on a socket your code isn’t listening on.
-- **NIP-44 drift:** Different builds of `nip44` can disagree on encrypt/decrypt, so replies arrive but never parse.
-
-### How to import Nostr helpers
-Import all required Nostr values and types directly from `@shocknet/clink-sdk` instead of `nostr-tools`:
+| Cause | What happens |
+|-------|----------------|
+| Separate `SimplePool` instances | Pool from your copy and pool from the SDK do not share sockets; events land on a connection you aren’t listening on. |
+| Divergent `nip44` builds | Encrypt/decrypt disagree; replies arrive but fail to decrypt and are dropped. |
 
 ```ts
 import {
@@ -39,43 +34,50 @@ import {
 } from '@shocknet/clink-sdk';
 ```
 
----
-
-## 2. Troubleshooting "No Response" / Timeouts
-
-If your application sends a request (Offer, Debit, or Manage) but times out waiting for a response, it is almost always due to one of the following:
-
-### A. Wrong NIP-44 Encryption Implementation
-If you are communicating with a peer running a different implementation (e.g. a custom C# plugin or an older wallet), an encryption mismatch will cause incoming responses to be undecryptable. The SDK will silently ignore undecryptable events and eventually time out.
-- **Check:** Ensure both sides use NIP-44 v2 spec-compliant encryption. See the [Porting](#3-porting-to-other-languages-c-go-etc) section below for exact vector specifications.
-
-### B. Publish-Before-Subscribe Race Condition
-If you publish a request to a relay *before* setting up your subscription for the response, a fast responder (like a CLINK wallet) may publish its reply before your subscription is active.
-- **Check:** Always establish your subscription filter (listening for `#e` matching your request event ID) *before* sending the `EVENT` message to the relay. The `@shocknet/clink-sdk` handles this order of operations internally.
-
-### C. Leaking Subscriptions
-If you are managing your own relay subscriptions or connection loops, failing to close old subscriptions will leak resources and can degrade relay performance or cause connection limits to be hit.
-- **Check:** Ensure you call `close()` on the subscription handle (`SubCloser`) as soon as the primary response is received.
+If you pass a custom `pool` into `ClinkSDK`, create it with `SimplePool` from this package.
 
 ---
 
-## 3. Porting to Other Languages (C#, Go, etc.)
+## 2. Troubleshooting "no response" / timeouts
 
-If you are writing a CLINK client or plugin in a language other than TypeScript/JavaScript, **do not implement NIP-44 or the CLINK TLV/Bech32 encoding from scratch without testing against the official vectors.**
+Most often the peer service is down, or your client is not connected to the relay. Confirm both before debugging further.
 
-Refer to [`test-vectors/interop.json`](../test-vectors/interop.json) as the strict contract for interoperability.
+If the service is up and the relay connection is open, a timeout is usually one of:
 
-### Common Language Porting Footguns
+### A. Wrong NIP-44
+Replies arrive but fail to decrypt; the SDK drops them and the request waits until timeout.
+- **Check:** Both sides use NIP-44 v2. See [Porting](#3-porting-to-other-languages) for key derivation. JS apps: use `nip44` from this package, not a separate install.
 
-| Mistake | What went wrong | Symptom |
-|---------|-----------------|---------|
-| **Incorrect Conversation Key Salt** | Deriving the conversation key using `HMAC("nip44-v2", sharedX)` instead of `HKDF-Extract(salt="nip44-v2", IKM=sharedX)`. | Peer cannot decrypt your events; you cannot decrypt theirs. |
-| **Incorrect Message Keys Derivation** | Using a custom HKDF info string (like `"nip44-v2-keys"`) instead of a single `HKDF-Expand` with the 32-byte raw nonce as info. | Same as above. |
-| **2-Byte TLV Lengths** | Encoding or parsing TLV lengths as 2-byte big-endian integers. CLINK TLV uses **1-byte lengths** (`type (1) \| length (1) | value (length)`). | `noffer1` / `ndebit1` strings decode into garbage; routing/auth fails. |
-| **Swapped TLV Tags** | Swapping tag `0` (pubkey) and tag `1` (relay). Tag `0` must be the 32-byte raw public key; tag `1` must be the UTF-8 relay URL. | Bech32 strings fail to decode or route to the wrong relay. |
-| **Publish, then Subscribe** | Publishing the request event to the relay before sending the subscription request. | Intermittent timeouts, especially on fast relays or local networks. |
+### B. Publish before subscribe
+The reply is published before your listener is attached; the event is missed and surfaces as a timeout.
+- **Check:** Subscribe for the reply (`#e` = request id) *before* sending the request `EVENT`. `@shocknet/clink-sdk` does this internally.
 
-### Recommended Porting Workflow
-1. **Assert Bech32/TLV Decodes:** Verify your decoder can parse the sample `noffer` and `ndebit` strings in `test-vectors/interop.json` and extract the exact fields.
-2. **Assert NIP-44 Key Derivation:** Verify that your ECDH shared-secret and HKDF key derivation matches the fixed conversation-key vector in `test-vectors/interop.json`.
-3. **Test E2E with a Relay:** Verify your client can communicate with a standard JS/TS client or wallet before deploying to production.
+### C. Leaking subscriptions
+Leaving subscriptions open after the primary response wastes relay slots and can hit connection limits on long-running processes.
+- **Check:** Call `close()` on the `SubCloser` when the primary response arrives. The SDK does this for you.
+
+---
+
+## 3. Porting to other languages
+
+Two stacks must match this SDK:
+
+1. **NIP-44 v2** — encrypt/decrypt of kind `21001` / `21002` / `21003` content.
+2. **NIP-19-style bech32** — `noffer1` / `ndebit1` / `nmanage1`. Same layout as other NIP-19 entities (`nprofile`, etc.): bech32 around a TLV byte stream. CLINK only defines the HRPs and tag meanings.
+
+Implement against [`test-vectors/interop.json`](../test-vectors/interop.json).
+
+### Common mistakes
+
+| Mistake | Detail | Symptom |
+|---------|--------|---------|
+| **Wrong conversation key** | `HMAC("nip44-v2", sharedX)` instead of `HKDF-Extract(salt="nip44-v2", IKM=sharedX)`. | Undecryptable events appear as timeouts. |
+| **Wrong message keys** | Custom HKDF info (e.g. `"nip44-v2-keys"`) instead of `HKDF-Expand` with the raw 32-byte nonce as info. | Same. |
+| **2-byte TLV lengths** | NIP-19 TLV is `type (1) \| length (1) \| value (length)` — length is one byte (0–255), not a 2-byte big-endian int. | Bech32 decode fails or fields are garbage. |
+| **Wrong / missing TLV tags** | Tags and meanings are in `interop.json`. Tag `0` is 32 raw pubkey bytes (not UTF-8 hex); tag `1` is the relay URL. Omit a required tag, swap 0/1, or UTF-8-decode the pubkey and the pointer is wrong. | Decoded pubkey/relay/offer/pointer mismatch; requests misroute or fail auth. |
+| **Publish before subscribe** | Sending the request `EVENT` before subscribing for the reply (`#e` = request id). | Missed responses appear as timeouts when the peer replies quickly. |
+
+### Porting checklist
+1. Decode the sample `noffer1` / `ndebit1` strings in `interop.json`; assert every field matches.
+2. Assert your NIP-44 conversation key matches the fixed vector in `interop.json`.
+3. Only then test end-to-end against a known-good JS client over a relay.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@shocknet/clink-sdk",
-    "version": "1.5.5",
+    "version": "1.6.0",
     "description": "sdk client for clink",
     "repository": {
         "type": "git",

--- a/package.json
+++ b/package.json
@@ -10,8 +10,13 @@
     "scripts": {
         "clean": "rimraf build",
         "prepack": "npm run clean && tsc",
-        "test": "echo \"Error: no test specified\" && exit 1",
-        "start": "npm run prepack && node build/index.js"
+        "test": "npm run prepack && node --test test/unit/*.test.mjs",
+        "start": "npm run prepack && node build/index.js",
+        "test:unit": "node --test test/unit/*.test.mjs",
+        "test:setup-trees": "node test/compat/setup-trees.mjs",
+        "test:compat-offline": "node test/compat/setup-trees.mjs && node --test test/compat/cross-decrypt.test.mjs",
+        "test:compat-relay": "node --test test/compat/relay-client.test.mjs",
+        "test:wait-relay": "node test/compat/wait-for-relay.mjs"
     },
     "type": "module",
     "author": "",

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,6 +38,11 @@ export class ClinkSDK {
         return SendNmanageRequest(this.pool, this.settings.privateKey, this.settings.relays, this.settings.toPubKey, data, timeoutSeconds || this.settings.defaultTimeoutSeconds)
     }
 
+    /** Close relay connections. Call when done so the process can exit. */
+    Stop = () => {
+        this.pool.destroy()
+    }
+
     static decodeBech32 = decodeBech32
     static generateSecretKey = generateSecretKey
     static newListRequest = newListRequest

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { AbstractSimplePool, SubCloser } from "nostr-tools/lib/types/pool"
 import { SimplePool, getPublicKey, nip19, generateSecretKey, finalizeEvent, nip44, verifyEvent, type UnsignedEvent } from "nostr-tools"
 import { SendNofferRequest, NofferData, NofferReceipt } from "./noffer.js"
-import { NdebitData, SendNdebitRequest, newNdebitBudgetRequest } from "./ndebit.js"
+import { NdebitData, SendNdebitRequest, generateK1, newNdebitBudgetRequest, newNdebitPaymentRequest } from "./ndebit.js"
 import { NmanageRequest, SendNmanageRequest, newListRequest } from "./nmanage.js"
 import { decodeBech32 } from "./nip19Extension.js"
 
@@ -42,6 +42,8 @@ export class ClinkSDK {
     static generateSecretKey = generateSecretKey
     static newListRequest = newListRequest
     static newNdebitBudgetRequest = newNdebitBudgetRequest
+    static newNdebitPaymentRequest = newNdebitPaymentRequest
+    static generateK1 = generateK1
 }
 
 export * from './nip19Extension.js'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,10 @@
-import { AbstractSimplePool, SubCloser } from "nostr-tools/lib/types/pool"
+import { AbstractSimplePool } from "nostr-tools/lib/types/pool"
 import { SimplePool, getPublicKey, nip19, generateSecretKey, finalizeEvent, nip44, verifyEvent, type UnsignedEvent } from "nostr-tools"
 import { SendNofferRequest, NofferData, NofferReceipt } from "./noffer.js"
-import { NdebitData, SendNdebitRequest, generateK1, newNdebitBudgetRequest, newNdebitPaymentRequest } from "./ndebit.js"
+import { NdebitData, SendNdebitRequest, generateK1, validateK1, newNdebitBudgetRequest, newNdebitPaymentRequest } from "./ndebit.js"
 import { NmanageRequest, SendNmanageRequest, newListRequest } from "./nmanage.js"
 import { decodeBech32 } from "./nip19Extension.js"
-
-//pool: AbstractSimplePool, privateKey: Uint8Array, relays: string[], toPubKey: string, data: NofferData, timeoutSeconds = 30
+import { setDebug } from "./sender.js"
 
 export type ClinkSettings = {
     privateKey: Uint8Array
@@ -49,12 +48,14 @@ export class ClinkSDK {
     static newNdebitBudgetRequest = newNdebitBudgetRequest
     static newNdebitPaymentRequest = newNdebitPaymentRequest
     static generateK1 = generateK1
+    static validateK1 = validateK1
 }
 
 export * from './nip19Extension.js'
 export * from './noffer.js'
 export * from './nmanage.js'
 export * from "./ndebit.js"
+export { setDebug }
 /** Re-exported from the SDK's pinned nostr-tools — import these here, do not install nostr-tools yourself. */
 export { SimplePool, getPublicKey, nip19, generateSecretKey, finalizeEvent, nip44, verifyEvent }
 export type { AbstractSimplePool, UnsignedEvent }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,9 @@
 import { AbstractSimplePool, SubCloser } from "nostr-tools/lib/types/pool"
-import { SimplePool, getPublicKey, nip19, generateSecretKey } from "nostr-tools"
+import { SimplePool, getPublicKey, nip19, generateSecretKey, finalizeEvent, nip44, verifyEvent, type UnsignedEvent } from "nostr-tools"
 import { SendNofferRequest, NofferData, NofferReceipt } from "./noffer.js"
 import { NdebitData, SendNdebitRequest, newNdebitBudgetRequest } from "./ndebit.js"
 import { NmanageRequest, SendNmanageRequest, newListRequest } from "./nmanage.js"
 import { decodeBech32 } from "./nip19Extension.js"
-
-
-
 
 //pool: AbstractSimplePool, privateKey: Uint8Array, relays: string[], toPubKey: string, data: NofferData, timeoutSeconds = 30
 
@@ -51,4 +48,6 @@ export * from './nip19Extension.js'
 export * from './noffer.js'
 export * from './nmanage.js'
 export * from "./ndebit.js"
-export { SimplePool, getPublicKey, nip19, generateSecretKey }
+/** Re-exported from the SDK's pinned nostr-tools — import these here, do not install nostr-tools yourself. */
+export { SimplePool, getPublicKey, nip19, generateSecretKey, finalizeEvent, nip44, verifyEvent }
+export type { AbstractSimplePool, UnsignedEvent }

--- a/src/ndebit.ts
+++ b/src/ndebit.ts
@@ -1,3 +1,4 @@
+import { randomBytes, bytesToHex } from '@noble/hashes/utils'
 import { nip44, getPublicKey, finalizeEvent } from "nostr-tools"
 import { AbstractSimplePool, SubCloser } from "nostr-tools/lib/types/pool"
 import { sendRequest } from "./sender.js"
@@ -5,7 +6,19 @@ const { getConversationKey, decrypt, encrypt } = nip44
 
 export type RecurringDebitTimeUnit = 'day' | 'week' | 'month'
 export type BudgetFrequency = { number: number, unit: RecurringDebitTimeUnit }
-export type NdebitData = { pointer?: string, amount_sats?: number, bolt11?: string, frequency?: BudgetFrequency, k1?: string }
+export type NdebitData = { pointer?: string, amount_sats?: number, bolt11?: string, frequency?: BudgetFrequency, k1?: string, description?: string }
+
+const K1_HEX_RE = /^[0-9a-f]{64}$/
+
+export const validateK1 = (k1: unknown): string => {
+    if (typeof k1 !== 'string' || !K1_HEX_RE.test(k1)) {
+        throw new Error('k1 must be 64 lowercase hex characters')
+    }
+    return k1
+}
+
+/** 32 random bytes as lowercase hex — for minting session ndebit TLV `3`. */
+export const generateK1 = (): string => bytesToHex(randomBytes(32))
 
 export type NdebitSuccess = { res: 'ok', preimage?: string }
 export type NdebitFailure = { res: 'GFY', error: string, code: number }
@@ -48,12 +61,14 @@ export const newNdebitFullAccessRequest = (pointer?: string): NdebitData => {
         pointer: pointer
     }
 }
-export const newNdebitPaymentRequest = (invoice: string, amount?: number, pointer?: string): NdebitData => {
-    return {
+export const newNdebitPaymentRequest = (invoice: string, amount?: number, pointer?: string, k1?: string): NdebitData => {
+    const req: NdebitData = {
         bolt11: invoice,
         amount_sats: amount,
-        pointer: pointer
+        pointer: pointer,
     }
+    if (k1 !== undefined) req.k1 = validateK1(k1)
+    return req
 }
 
 export const newNdebitBudgetRequest = (frequency: BudgetFrequency, amount: number, pointer?: string): NdebitData => {

--- a/src/ndebit.ts
+++ b/src/ndebit.ts
@@ -21,6 +21,31 @@ export const validateK1 = (k1: unknown): string => {
 /** 32 random bytes as lowercase hex — for minting session ndebit TLV `3`. */
 export const generateK1 = (): string => bytesToHex(randomBytes(32))
 
+export const validateBudgetFrequency = (frequency: unknown): BudgetFrequency => {
+    if (typeof frequency !== 'object' || frequency === null) throw new Error('frequency must be an object')
+    if (!('number' in frequency) || typeof frequency.number !== 'number') throw new Error('frequency.number must be a number')
+    if (frequency.number <= 0 || !Number.isInteger(frequency.number)) throw new Error('frequency.number must be a positive integer')
+    if (!('unit' in frequency) || typeof frequency.unit !== 'string') throw new Error('frequency.unit must be a string')
+    if (frequency.unit !== 'day' && frequency.unit !== 'week' && frequency.unit !== 'month') {
+        throw new Error('frequency.unit must be day, week, or month')
+    }
+    return frequency as BudgetFrequency
+}
+
+export const validateNdebitData = (data: unknown): NdebitData => {
+    if (typeof data !== 'object' || data === null) throw new Error('data must be an object')
+    if ('pointer' in data && typeof data.pointer !== 'string') throw new Error('pointer must be a string if present')
+    if ('amount_sats' in data && typeof data.amount_sats !== 'number') throw new Error('amount_sats must be a number if present')
+    if ('bolt11' in data && typeof data.bolt11 !== 'string') throw new Error('bolt11 must be a string if present')
+    if ('frequency' in data) validateBudgetFrequency(data.frequency)
+    if ('k1' in data) validateK1(data.k1)
+    if ('description' in data) {
+        if (typeof data.description !== 'string') throw new Error('description must be a string if present')
+        assertDescription(data.description)
+    }
+    return data as NdebitData
+}
+
 const assertDescription = (description?: string) => {
     if (description !== undefined && description.length > DESC_MAX) {
         throw new Error('Description must be less than 100 characters')

--- a/src/ndebit.ts
+++ b/src/ndebit.ts
@@ -1,14 +1,15 @@
 import { randomBytes, bytesToHex } from '@noble/hashes/utils'
-import { nip44, getPublicKey, finalizeEvent } from "nostr-tools"
-import { AbstractSimplePool, SubCloser } from "nostr-tools/lib/types/pool"
+import { nip44, getPublicKey } from "nostr-tools"
+import { AbstractSimplePool } from "nostr-tools/lib/types/pool"
 import { sendRequest } from "./sender.js"
-const { getConversationKey, decrypt, encrypt } = nip44
+const { getConversationKey, encrypt } = nip44
 
 export type RecurringDebitTimeUnit = 'day' | 'week' | 'month'
 export type BudgetFrequency = { number: number, unit: RecurringDebitTimeUnit }
 export type NdebitData = { pointer?: string, amount_sats?: number, bolt11?: string, frequency?: BudgetFrequency, k1?: string, description?: string }
 
 const K1_HEX_RE = /^[0-9a-f]{64}$/
+const DESC_MAX = 100
 
 export const validateK1 = (k1: unknown): string => {
     if (typeof k1 !== 'string' || !K1_HEX_RE.test(k1)) {
@@ -20,35 +21,18 @@ export const validateK1 = (k1: unknown): string => {
 /** 32 random bytes as lowercase hex — for minting session ndebit TLV `3`. */
 export const generateK1 = (): string => bytesToHex(randomBytes(32))
 
+const assertDescription = (description?: string) => {
+    if (description !== undefined && description.length > DESC_MAX) {
+        throw new Error('Description must be less than 100 characters')
+    }
+}
+
 export type NdebitSuccess = { res: 'ok', preimage?: string }
 export type NdebitFailure = { res: 'GFY', error: string, code: number }
 export type NdebitResponse = NdebitSuccess | NdebitFailure
 
-/* export const SendNdebitRequest = async (pool: AbstractSimplePool, privateKey: Uint8Array, relays: string[], pubKey: string, data: NdebitData, timeoutSeconds?: number): Promise<NdebitResponse> => {
-    const publicKey = getPublicKey(privateKey)
-    const content = encrypt(JSON.stringify(data), getConversationKey(privateKey, pubKey))
-    const event = newNdebitEvent(content, publicKey, pubKey)
-    const signed = finalizeEvent(event, privateKey)
-    await Promise.all(pool.publish(relays, signed))
-    return new Promise<NdebitResponse>((res, rej) => {
-        let closer: SubCloser = { close: () => { } }
-        let timer: NodeJS.Timeout | null = null
-        if (timeoutSeconds) {
-            timer = setTimeout(() => {
-                closer.close(); rej('failed to get ndebit response in time')
-            }, timeoutSeconds * 1000)
-        }
-        closer = pool.subscribeMany(relays, [newNdebitFilter(publicKey, signed.id)], {
-            onevent: async (e) => {
-                if (timer) clearTimeout(timer)
-                const content = decrypt(e.content, getConversationKey(privateKey, pubKey))
-                res(JSON.parse(content))
-            }
-        })
-    })
-} */
-
 export const SendNdebitRequest = async (pool: AbstractSimplePool, privateKey: Uint8Array, relays: string[], toPubKey: string, data: NdebitData, timeoutSeconds?: number): Promise<NdebitResponse> => {
+    assertDescription(data.description)
     const publicKey = getPublicKey(privateKey)
     const content = encrypt(JSON.stringify(data), getConversationKey(privateKey, toPubKey))
     const event = newNdebitEvent(content, publicKey, toPubKey)
@@ -61,22 +45,27 @@ export const newNdebitFullAccessRequest = (pointer?: string): NdebitData => {
         pointer: pointer
     }
 }
-export const newNdebitPaymentRequest = (invoice: string, amount?: number, pointer?: string, k1?: string): NdebitData => {
+export const newNdebitPaymentRequest = (invoice: string, amount?: number, pointer?: string, k1?: string, description?: string): NdebitData => {
+    assertDescription(description)
     const req: NdebitData = {
         bolt11: invoice,
         amount_sats: amount,
         pointer: pointer,
     }
     if (k1 !== undefined) req.k1 = validateK1(k1)
+    if (description !== undefined) req.description = description
     return req
 }
 
-export const newNdebitBudgetRequest = (frequency: BudgetFrequency, amount: number, pointer?: string): NdebitData => {
-    return {
+export const newNdebitBudgetRequest = (frequency: BudgetFrequency, amount: number, pointer?: string, description?: string): NdebitData => {
+    assertDescription(description)
+    const req: NdebitData = {
         amount_sats: amount,
         frequency: frequency,
         pointer: pointer
     }
+    if (description !== undefined) req.description = description
+    return req
 }
 
 export const newNdebitEvent = (content: string, fromPub: string, toPub: string) => ({

--- a/src/nip19Extension.ts
+++ b/src/nip19Extension.ts
@@ -58,6 +58,8 @@ export type DebitPointer = {
   pubkey: string,
   relay: string,
   pointer?: string,
+  /** Session id (32-byte lowercase hex) — encoded as TLV type 3 when present. */
+  k1?: string,
 }
 
 type Prefixes = {
@@ -105,12 +107,14 @@ export function decodeBech32(nip19: string): DecodeResult {
       if (!tlv[0]?.[0]) throw new Error('missing TLV 0 for ndebit')
       if (tlv[0][0].length !== 32) throw new Error('TLV 0 should be 32 bytes')
       if (!tlv[1]?.[0]) throw new Error('missing TLV 1 for ndebit')
+      if (tlv[3] && tlv[3][0].length !== 32) throw new Error('TLV 3 should be 32 bytes if present')
       return {
         type: 'ndebit',
         data: {
           pubkey: bytesToHex(tlv[0][0]),
           relay: utf8Decoder.decode(tlv[1][0]),
-          pointer: tlv[2] ? utf8Decoder.decode(tlv[2][0]) : undefined
+          pointer: tlv[2] ? utf8Decoder.decode(tlv[2][0]) : undefined,
+          k1: tlv[3] ? bytesToHex(tlv[3][0]) : undefined,
         }
       }
     }
@@ -173,6 +177,11 @@ export const ndebitEncode = (debit: DebitPointer): string => {
   }
   if (debit.pointer) {
     o[2] = [utf8Encoder.encode(debit.pointer)]
+  }
+  if (debit.k1) {
+    const k1 = hexToBytes(debit.k1)
+    if (k1.length !== 32) throw new Error('raw K1 buffer should be 32 bytes')
+    o[3] = [k1]
   }
   const data = encodeTLV(o)
   const words = bech32.toWords(data)

--- a/src/nmanage.ts
+++ b/src/nmanage.ts
@@ -1,7 +1,7 @@
-import { nip44, getPublicKey, finalizeEvent, UnsignedEvent } from "nostr-tools"
-import { AbstractSimplePool, SubCloser } from "nostr-tools/lib/types/pool"
+import { nip44, getPublicKey } from "nostr-tools"
+import { AbstractSimplePool } from "nostr-tools/lib/types/pool"
 import { sendRequest } from "./sender.js"
-const { getConversationKey, decrypt, encrypt } = nip44
+const { getConversationKey, encrypt } = nip44
 
 type ErrorDelta = { max_delta_ms: number, actual_delta_ms: number }
 type ErrorRange = { min: number, max: number }
@@ -34,6 +34,34 @@ export type NmanageCreateOffer = {
     }
 }
 
+const validateResourceAndAction = (data: unknown, expected: { resource: string, action: string }): object => {
+    if (typeof data !== 'object' || data === null) throw new Error('data must be an object')
+    if (!('resource' in data) || typeof data.resource !== 'string') throw new Error('resource must be a string')
+    if (data.resource !== expected.resource) throw new Error('resource type not supported')
+    if (!('action' in data) || typeof data.action !== 'string') throw new Error('action must be a string')
+    if (data.action !== expected.action) throw new Error('action not supported')
+    return data as object
+}
+
+export const validateOfferFields = (fields: unknown): OfferFields => {
+    if (typeof fields !== 'object' || fields === null) throw new Error('fields must be an object')
+    if (!('label' in fields) || typeof fields.label !== 'string') throw new Error('label must be a string')
+    if (!('price_sats' in fields) || typeof fields.price_sats !== 'number') throw new Error('price_sats must be a number')
+    if (!('callback_url' in fields) || typeof fields.callback_url !== 'string') throw new Error('callback_url must be a string')
+    if (!('payer_data' in fields) || !Array.isArray(fields.payer_data)) throw new Error('payer_data must be an array')
+    if (fields.payer_data.some(item => typeof item !== 'string')) throw new Error('payer_data must be an array of strings')
+    return fields as OfferFields
+}
+
+export const validateNmanageCreateOffer = (data: unknown): NmanageCreateOffer => {
+    const obj = validateResourceAndAction(data, { resource: 'offer', action: 'create' })
+    if ('pointer' in obj && typeof obj.pointer !== 'string') throw new Error('pointer must be a string if present')
+    if (!('offer' in obj) || typeof obj.offer !== 'object' || obj.offer === null) throw new Error('offer must be an object')
+    if (!('fields' in obj.offer) || typeof obj.offer.fields !== 'object' || obj.offer.fields === null) throw new Error('fields must be an object')
+    validateOfferFields(obj.offer.fields)
+    return obj as NmanageCreateOffer
+}
+
 export type NmanageUpdateOffer = {
     resource: 'offer',
     action: 'update',
@@ -41,6 +69,15 @@ export type NmanageUpdateOffer = {
         id: string,
         fields: OfferFields
     }
+}
+
+export const validateNmanageUpdateOffer = (data: unknown): NmanageUpdateOffer => {
+    const obj = validateResourceAndAction(data, { resource: 'offer', action: 'update' })
+    if (!('offer' in obj) || typeof obj.offer !== 'object' || obj.offer === null) throw new Error('offer must be an object')
+    if (!('id' in obj.offer) || typeof obj.offer.id !== 'string') throw new Error('id must be a string')
+    if (!('fields' in obj.offer) || typeof obj.offer.fields !== 'object' || obj.offer.fields === null) throw new Error('fields must be an object')
+    validateOfferFields(obj.offer.fields)
+    return obj as NmanageUpdateOffer
 }
 
 export type NmanageDeleteOffer = {
@@ -51,6 +88,13 @@ export type NmanageDeleteOffer = {
     }
 }
 
+export const validateNmanageDeleteOffer = (data: unknown): NmanageDeleteOffer => {
+    const obj = validateResourceAndAction(data, { resource: 'offer', action: 'delete' })
+    if (!('offer' in obj) || typeof obj.offer !== 'object' || obj.offer === null) throw new Error('offer must be an object')
+    if (!('id' in obj.offer) || typeof obj.offer.id !== 'string') throw new Error('id must be a string')
+    return obj as NmanageDeleteOffer
+}
+
 export type NmanageGetOffer = {
     resource: 'offer',
     action: 'get',
@@ -59,13 +103,45 @@ export type NmanageGetOffer = {
     }
 }
 
+export const validateNmanageGetOffer = (data: unknown): NmanageGetOffer => {
+    const obj = validateResourceAndAction(data, { resource: 'offer', action: 'get' })
+    if (!('offer' in obj) || typeof obj.offer !== 'object' || obj.offer === null) throw new Error('offer must be an object')
+    if (!('id' in obj.offer) || typeof obj.offer.id !== 'string') throw new Error('id must be a string')
+    return obj as NmanageGetOffer
+}
+
 export type NmanageListOffers = {
     resource: 'offer',
     action: 'list',
     pointer?: string,
 }
 
+export const validateNmanageListOffers = (data: unknown): NmanageListOffers => {
+    const obj = validateResourceAndAction(data, { resource: 'offer', action: 'list' })
+    if ('pointer' in obj && typeof obj.pointer !== 'string') throw new Error('pointer must be a string if present')
+    return obj as NmanageListOffers
+}
+
 export type NmanageRequest = NmanageCreateOffer | NmanageUpdateOffer | NmanageDeleteOffer | NmanageGetOffer | NmanageListOffers
+
+export const validateNmanageRequest = (data: unknown): NmanageRequest => {
+    if (typeof data !== 'object' || data === null) throw new Error('data must be an object')
+    const action = 'action' in data ? data.action : undefined
+    switch (action) {
+        case 'create':
+            return validateNmanageCreateOffer(data)
+        case 'update':
+            return validateNmanageUpdateOffer(data)
+        case 'delete':
+            return validateNmanageDeleteOffer(data)
+        case 'get':
+            return validateNmanageGetOffer(data)
+        case 'list':
+            return validateNmanageListOffers(data)
+        default:
+            throw new Error('nmanage request action not supported')
+    }
+}
 
 export const SendNmanageRequest = async (pool: AbstractSimplePool, privateKey: Uint8Array, relays: string[], toPubKey: string, data: NmanageRequest, timeoutSeconds?: number): Promise<NmanageResponse> => {
     const publicKey = getPublicKey(privateKey)

--- a/src/noffer.ts
+++ b/src/noffer.ts
@@ -3,7 +3,28 @@ import { AbstractSimplePool } from "nostr-tools/lib/types/pool"
 import { sendRequest } from "./sender.js"
 const { getConversationKey, encrypt } = nip44
 
-export type NofferData = { offer: string, amount_sats?: number, zap?: string, payer_data?: any, expires_in_seconds?:number, description?:string }
+export type NofferData = {
+    offer: string
+    amount_sats?: number
+    zap?: string
+    payer_data?: Record<string, string>
+    expires_in_seconds?: number
+    description?: string
+}
+
+export const validateNofferData = (data: unknown): NofferData => {
+    if (typeof data !== 'object' || data === null) throw new Error('data must be an object')
+    if (!('offer' in data) || typeof data.offer !== 'string') throw new Error('offer must be a string')
+    if ('amount_sats' in data && typeof data.amount_sats !== 'number') throw new Error('amount_sats must be a number if present')
+    if ('zap' in data && typeof data.zap !== 'string') throw new Error('zap must be a string if present')
+    if ('payer_data' in data && (typeof data.payer_data !== 'object' || data.payer_data === null || Array.isArray(data.payer_data))) {
+        throw new Error('payer_data must be an object if present')
+    }
+    if ('expires_in_seconds' in data && typeof data.expires_in_seconds !== 'number') throw new Error('expires_in_seconds must be a number if present')
+    if ('description' in data && typeof data.description !== 'string') throw new Error('description must be a string if present')
+    return data as NofferData
+}
+
 export type NofferSuccess = { bolt11: string }
 export type NofferError = { code: number, error: string, range?: { min: number, max: number } }
 export type NofferResponse = NofferSuccess | NofferError

--- a/src/sender.ts
+++ b/src/sender.ts
@@ -8,35 +8,63 @@ export const sendRequest = async <T>(pool: AbstractSimplePool, pair: Pair, relay
     console.log(`[ClinkSDK] Sending request: kind=${kindExpected}, eventId=${signed.id}, toPub=${toPub}, relays=${relays.join(',')}, timeout=${timeoutSeconds}s`)
     
     return new Promise<T>((res, rej) => {
-        let resolved = false
+        let settled = false
+        let gotPrimary = false
         let closer: SubCloser = { close: () => { } }
-        let timer: NodeJS.Timeout | null = null
+        let timer: any = null
         
         const filter = newFilter(pair.publicKey, signed.id, kindExpected)
         console.log(`[ClinkSDK] Setting up subscription with filter:`, JSON.stringify(filter, null, 2))
+
+        const cleanup = () => {
+            if (timer) {
+                clearTimeout(timer)
+                timer = null
+            }
+            closer.close()
+        }
+
+        const fail = (err: unknown) => {
+            if (settled) return
+            settled = true
+            cleanup()
+            rej(err)
+        }
         
         if (timeoutSeconds) {
             timer = setTimeout(() => {
                 console.log(`[ClinkSDK] Timeout after ${timeoutSeconds}s - no response received for kind=${kindExpected}, eventId=${signed.id}`)
-                console.log(`[ClinkSDK] Closing subscription for eventId=${signed.id}`)
-                closer.close(); rej('failed to get response in time')
+                fail('failed to get response in time')
             }, timeoutSeconds * 1000)
         }
         
         try {
-            // Set up subscription BEFORE publishing to avoid race condition
+            // Subscribe BEFORE publish — otherwise a fast reply can arrive with no listener
             closer = pool.subscribeMany(relays, [filter], {
                 onevent: async (e) => {
                     console.log(`[ClinkSDK] Received response event: kind=${e.kind}, eventId=${e.id}, from=${e.pubkey}`)
-                    if (timer) clearTimeout(timer)
-                    const content = decrypt(e.content, getConversationKey(pair.privateKey, toPub))
-                    if (!resolved) {
-                        resolved = true
-                        console.log(`[ClinkSDK] Response resolved successfully for eventId=${signed.id}`)
-                        res(JSON.parse(content))
-                    } else {
-                        console.log(`[ClinkSDK] Additional response received for eventId=${signed.id}, calling moreCb`)
-                        moreCb?.(JSON.parse(content))
+                    try {
+                        const content = decrypt(e.content, getConversationKey(pair.privateKey, toPub))
+                        const parsed = JSON.parse(content)
+                        if (!gotPrimary) {
+                            gotPrimary = true
+                            if (timer) {
+                                clearTimeout(timer)
+                                timer = null
+                            }
+                            console.log(`[ClinkSDK] Response resolved successfully for eventId=${signed.id}`)
+                            settled = true
+                            res(parsed)
+                            // Keep the sub open only when a follow-up is expected (e.g. Noffer payment receipt)
+                            if (!moreCb) cleanup()
+                        } else {
+                            console.log(`[ClinkSDK] Additional response received for eventId=${signed.id}, calling moreCb`)
+                            moreCb?.(parsed)
+                            cleanup()
+                        }
+                    } catch (err) {
+                        console.error(`[ClinkSDK] Failed to decrypt/parse response for eventId=${signed.id}:`, err)
+                        fail(err)
                     }
                 },
                 oneose: () => {
@@ -45,19 +73,15 @@ export const sendRequest = async <T>(pool: AbstractSimplePool, pair: Pair, relay
             })
             console.log(`[ClinkSDK] Subscription established for eventId=${signed.id}`)
             
-            // Publish AFTER subscription is set up to avoid missing the response
             Promise.all(pool.publish(relays, signed)).then(() => {
                 console.log(`[ClinkSDK] Request published to ${relays.length} relays, waiting for response...`)
             }).catch((error) => {
                 console.error(`[ClinkSDK] Failed to publish to relays:`, error)
-                if (timer) clearTimeout(timer)
-                closer.close()
-                rej(error)
+                fail(error)
             })
         } catch (error) {
             console.error(`[ClinkSDK] Failed to establish subscription:`, error)
-            if (timer) clearTimeout(timer)
-            rej(error)
+            fail(error)
         }
     })
 }

--- a/src/sender.ts
+++ b/src/sender.ts
@@ -2,19 +2,35 @@ import { nip44, finalizeEvent, UnsignedEvent } from "nostr-tools"
 import { AbstractSimplePool, SubCloser } from "nostr-tools/lib/types/pool"
 const { getConversationKey, decrypt } = nip44
 
+let debug = false
+
+/** Enable verbose relay lifecycle logs (default off) — handy while integrating. */
+export const setDebug = (enabled: boolean) => {
+    debug = enabled
+}
+
+const log = (...args: unknown[]) => {
+    if (debug) console.log(...args)
+}
+
+const logError = (...args: unknown[]) => {
+    if (debug) console.error(...args)
+}
+
 type Pair = { privateKey: Uint8Array, publicKey: string }
 export const sendRequest = async <T>(pool: AbstractSimplePool, pair: Pair, relays: string[], toPub: string, e: UnsignedEvent, kindExpected: number, timeoutSeconds?: number, moreCb?: (data: any) => void): Promise<T> => {
     const signed = finalizeEvent(e, pair.privateKey)
-    console.log(`[ClinkSDK] Sending request: kind=${kindExpected}, eventId=${signed.id}, toPub=${toPub}, relays=${relays.join(',')}, timeout=${timeoutSeconds}s`)
-    
+    // Wire events use lowercase hex; callers sometimes pass mixed case.
+    const expectedPub = toPub.toLowerCase()
+    log(`[ClinkSDK] Sending request: kind=${kindExpected}, eventId=${signed.id}, toPub=${expectedPub}, relays=${relays.join(',')}, timeout=${timeoutSeconds}s`)
+
     return new Promise<T>((res, rej) => {
         let settled = false
-        let gotPrimary = false
         let closer: SubCloser = { close: () => { } }
-        let timer: any = null
-        
+        let timer: ReturnType<typeof setTimeout> | null = null
+
         const filter = newFilter(pair.publicKey, signed.id, kindExpected)
-        console.log(`[ClinkSDK] Setting up subscription with filter:`, JSON.stringify(filter, null, 2))
+        log(`[ClinkSDK] Setting up subscription with filter:`, JSON.stringify(filter, null, 2))
 
         const cleanup = () => {
             if (timer) {
@@ -30,63 +46,68 @@ export const sendRequest = async <T>(pool: AbstractSimplePool, pair: Pair, relay
             cleanup()
             rej(err)
         }
-        
+
         if (timeoutSeconds) {
             timer = setTimeout(() => {
-                console.log(`[ClinkSDK] Timeout after ${timeoutSeconds}s - no response received for kind=${kindExpected}, eventId=${signed.id}`)
+                log(`[ClinkSDK] Timeout after ${timeoutSeconds}s - no response received for kind=${kindExpected}, eventId=${signed.id}`)
                 fail('failed to get response in time')
             }, timeoutSeconds * 1000)
         }
-        
+
         try {
             // Subscribe BEFORE publish — otherwise a fast reply can arrive with no listener
             closer = pool.subscribeMany(relays, [filter], {
                 onevent: async (e) => {
-                    console.log(`[ClinkSDK] Received response event: kind=${e.kind}, eventId=${e.id}, from=${e.pubkey}`)
+                    log(`[ClinkSDK] Received response event: kind=${e.kind}, eventId=${e.id}, from=${e.pubkey}`)
                     // Filter is tag-based only — ignore anyone who is not the expected peer so a
                     // forged #e/#p event cannot DoS the request by failing decrypt ahead of the real reply.
-                    if (e.pubkey !== toPub) {
-                        console.log(`[ClinkSDK] Ignoring event from unexpected pubkey ${e.pubkey} (expected ${toPub})`)
+                    if (e.pubkey !== expectedPub) {
+                        log(`[ClinkSDK] Ignoring event from unexpected pubkey ${e.pubkey} (expected ${expectedPub})`)
                         return
                     }
                     try {
-                        const content = decrypt(e.content, getConversationKey(pair.privateKey, toPub))
+                        const content = decrypt(e.content, getConversationKey(pair.privateKey, expectedPub))
                         const parsed = JSON.parse(content)
-                        if (!gotPrimary) {
-                            gotPrimary = true
+                        if (!settled) {
+                            settled = true
                             if (timer) {
                                 clearTimeout(timer)
                                 timer = null
                             }
-                            console.log(`[ClinkSDK] Response resolved successfully for eventId=${signed.id}`)
-                            settled = true
+                            log(`[ClinkSDK] Response resolved successfully for eventId=${signed.id}`)
                             res(parsed)
                             // Keep the sub open only when a follow-up is expected (e.g. Noffer payment receipt)
                             if (!moreCb) cleanup()
                         } else {
-                            console.log(`[ClinkSDK] Additional response received for eventId=${signed.id}, calling moreCb`)
+                            // Single receipt — invoke callback then close
+                            log(`[ClinkSDK] Additional response received for eventId=${signed.id}, calling moreCb`)
                             moreCb?.(parsed)
                             cleanup()
                         }
                     } catch (err) {
-                        console.error(`[ClinkSDK] Failed to decrypt/parse response for eventId=${signed.id}:`, err)
-                        fail(err)
+                        logError(`[ClinkSDK] Failed to decrypt/parse response for eventId=${signed.id}:`, err)
+                        if (!settled) {
+                            fail(err)
+                        } else {
+                            // Primary already delivered; bad follow-up — just close
+                            cleanup()
+                        }
                     }
                 },
                 oneose: () => {
-                    console.log(`[ClinkSDK] End of stored events received for eventId=${signed.id}`)
+                    log(`[ClinkSDK] End of stored events received for eventId=${signed.id}`)
                 }
             })
-            console.log(`[ClinkSDK] Subscription established for eventId=${signed.id}`)
-            
+            log(`[ClinkSDK] Subscription established for eventId=${signed.id}`)
+
             Promise.all(pool.publish(relays, signed)).then(() => {
-                console.log(`[ClinkSDK] Request published to ${relays.length} relays, waiting for response...`)
+                log(`[ClinkSDK] Request published to ${relays.length} relays, waiting for response...`)
             }).catch((error) => {
-                console.error(`[ClinkSDK] Failed to publish to relays:`, error)
+                logError(`[ClinkSDK] Failed to publish to relays:`, error)
                 fail(error)
             })
         } catch (error) {
-            console.error(`[ClinkSDK] Failed to establish subscription:`, error)
+            logError(`[ClinkSDK] Failed to establish subscription:`, error)
             fail(error)
         }
     })

--- a/src/sender.ts
+++ b/src/sender.ts
@@ -43,6 +43,12 @@ export const sendRequest = async <T>(pool: AbstractSimplePool, pair: Pair, relay
             closer = pool.subscribeMany(relays, [filter], {
                 onevent: async (e) => {
                     console.log(`[ClinkSDK] Received response event: kind=${e.kind}, eventId=${e.id}, from=${e.pubkey}`)
+                    // Filter is tag-based only — ignore anyone who is not the expected peer so a
+                    // forged #e/#p event cannot DoS the request by failing decrypt ahead of the real reply.
+                    if (e.pubkey !== toPub) {
+                        console.log(`[ClinkSDK] Ignoring event from unexpected pubkey ${e.pubkey} (expected ${toPub})`)
+                        return
+                    }
                     try {
                         const content = decrypt(e.content, getConversationKey(pair.privateKey, toPub))
                         const parsed = JSON.parse(content)

--- a/test-vectors/interop.json
+++ b/test-vectors/interop.json
@@ -5,7 +5,8 @@
     "notes": [
       "Length is a single byte (0–255), NOT 2-byte big-endian.",
       "Tag numbers and meanings are fixed — do not swap pubkey/relay; do not omit required tags.",
-      "Tag 0 (pubkey) is 32 raw bytes, not a UTF-8 hex string."
+      "Tag 0 (pubkey) is 32 raw bytes, not a UTF-8 hex string.",
+      "ndebit tag 3 (k1) is 32 raw bytes like tag 0, not a UTF-8 hex string."
     ],
     "noffer": {
       "0": "pubkey (32 bytes raw)",
@@ -17,7 +18,8 @@
     "ndebit": {
       "0": "pubkey (32 bytes raw)",
       "1": "relay (utf8)",
-      "2": "pointer (optional, utf8)"
+      "2": "pointer (optional, utf8)",
+      "3": "k1 session id (optional, 32 bytes raw — hex-encoded in NdebitData.k1)"
     },
     "nmanage": {
       "0": "pubkey (32 bytes raw)",
@@ -57,6 +59,15 @@
         "pubkey": "71b70bace4867c80be6b083d449c37486f33790df0ea4bbe6e9ce617bee34b66",
         "relay": "wss://relay.example.com",
         "pointer": "store_42"
+      }
+    },
+    "ndebit_session_k1": {
+      "encoded": "ndebit1qvsqzg69v7y6hn00qy352euf40x77qfrg4ncn27dauqjx3t83x4ummczppehgmmjv40ngvspzamhxue69uhhyetvv9ujuetcv9khqmr99e3k7mgqypcmwzavujr8eq97dvyr63yuxayx7vmephcw5ja7d6wwv9a7ud9kvg6dys8",
+      "decoded": {
+        "pubkey": "71b70bace4867c80be6b083d449c37486f33790df0ea4bbe6e9ce617bee34b66",
+        "relay": "wss://relay.example.com",
+        "pointer": "store_42",
+        "k1": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
       }
     }
   }

--- a/test-vectors/interop.json
+++ b/test-vectors/interop.json
@@ -1,0 +1,62 @@
+{
+  "description": "Interop vectors for CLINK language ports. A correct implementation MUST round-trip these. Do not invent NIP-44 or TLV encodings — match @shocknet/clink-sdk (and the NIP-44 version on the wire).",
+  "tlv": {
+    "layout": "type (1 byte) | length (1 byte) | value (length bytes)",
+    "notes": [
+      "Length is a single byte (0–255), NOT 2-byte big-endian.",
+      "Tag numbers and meanings are fixed — do not swap pubkey/relay."
+    ],
+    "noffer": {
+      "0": "pubkey (32 bytes raw)",
+      "1": "relay (utf8)",
+      "2": "offer id (utf8)",
+      "3": "priceType (1 byte: 0=Fixed, 1=Variable, 2=Spontaneous)",
+      "4": "price (optional, 4-byte big-endian uint32)"
+    },
+    "ndebit": {
+      "0": "pubkey (32 bytes raw)",
+      "1": "relay (utf8)",
+      "2": "pointer (optional, utf8)"
+    },
+    "nmanage": {
+      "0": "pubkey (32 bytes raw)",
+      "1": "relay (utf8)",
+      "2": "pointer (optional, utf8)"
+    }
+  },
+  "nip44_v2": {
+    "conversation_key": "HKDF-Extract(SHA-256, salt=UTF8(\"nip44-v2\"), IKM=ECDH shared X coordinate)",
+    "message_keys": "HKDF-Expand(SHA-256, PRK=conversation_key, info=32-byte nonce, L=76) → chacha_key(32) | chacha_nonce(12) | hmac_key(32)",
+    "payload": "version(1)=0x02 | nonce(32) | ciphertext | hmac(32)",
+    "not": [
+      "Do NOT use HMAC(key=\"nip44-v2\", msg=sharedX) for the conversation key",
+      "Do NOT use ChaCha20-Poly1305 AEAD with a 12-byte salt/nonce layout",
+      "Do NOT use HKDF info strings like \"nip44-v2-keys\" or \"nip44-v2-message-key\""
+    ],
+    "fixed_conversation_key_vector": {
+      "privkey_hex": "0000000000000000000000000000000000000000000000000000000000000001",
+      "peer_pubkey_hex": "c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5",
+      "conversation_key_hex": "c41c775356fd92eadc63ff5a0dc1da211b268cbea22316767095b2871ea1412d"
+    }
+  },
+  "bech32_roundtrip": {
+    "noffer": {
+      "encoded": "noffer1qszqqqqraqpszqqzp9hkven9wf0kzcnrqythwumn8ghj7un9d3shjtn90psk6urvv5hxxmmdqqs8rdct4njgvlyqhe4ss02ynsm5smen0yxlp6jthehfeeshhm35kes9yppf9",
+      "decoded": {
+        "pubkey": "71b70bace4867c80be6b083d449c37486f33790df0ea4bbe6e9ce617bee34b66",
+        "relay": "wss://relay.example.com",
+        "offer": "offer_abc",
+        "priceType": 0,
+        "price": 1000
+      }
+    },
+    "ndebit": {
+      "encoded": "ndebit1qgy8xar0wfj47dpjqythwumn8ghj7un9d3shjtn90psk6urvv5hxxmmdqqs8rdct4njgvlyqhe4ss02ynsm5smen0yxlp6jthehfeeshhm35kesh4xxz5",
+      "decoded": {
+        "pubkey": "71b70bace4867c80be6b083d449c37486f33790df0ea4bbe6e9ce617bee34b66",
+        "relay": "wss://relay.example.com",
+        "pointer": "store_42"
+      }
+    }
+  }
+}

--- a/test-vectors/interop.json
+++ b/test-vectors/interop.json
@@ -1,10 +1,11 @@
 {
-  "description": "Interop vectors for CLINK language ports. A correct implementation MUST round-trip these. Do not invent NIP-44 or TLV encodings — match @shocknet/clink-sdk (and the NIP-44 version on the wire).",
+  "description": "Interop vectors for CLINK language ports. A correct implementation MUST round-trip these. Do not invent NIP-44 or NIP-19-style TLV/bech32 — match @shocknet/clink-sdk (and the NIP-44 version on the wire).",
   "tlv": {
-    "layout": "type (1 byte) | length (1 byte) | value (length bytes)",
+    "layout": "type (1 byte) | length (1 byte) | value (length bytes) — same NIP-19 TLV layout as nprofile/etc.; CLINK defines HRPs and tag meanings only",
     "notes": [
       "Length is a single byte (0–255), NOT 2-byte big-endian.",
-      "Tag numbers and meanings are fixed — do not swap pubkey/relay."
+      "Tag numbers and meanings are fixed — do not swap pubkey/relay; do not omit required tags.",
+      "Tag 0 (pubkey) is 32 raw bytes, not a UTF-8 hex string."
     ],
     "noffer": {
       "0": "pubkey (32 bytes raw)",

--- a/test/compat/cross-decrypt.test.mjs
+++ b/test/compat/cross-decrypt.test.mjs
@@ -1,0 +1,81 @@
+import { describe, it, before } from 'node:test'
+import assert from 'node:assert/strict'
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
+import { loadCurrentSdk, loadPriorAppModules, readCompatMeta, toHex } from './paths.mjs'
+
+describe('tools API surface + self nip44', () => {
+  before(() => {
+    readCompatMeta()
+  })
+
+  it('exposes helpers and pool methods used by sender', async () => {
+    const sdk = await loadCurrentSdk()
+    assert.equal(typeof sdk.finalizeEvent, 'function')
+    assert.equal(typeof sdk.getPublicKey, 'function')
+    assert.equal(typeof sdk.SimplePool, 'function')
+    assert.equal(typeof sdk.nip44?.encrypt, 'function')
+    assert.equal(typeof sdk.nip44?.decrypt, 'function')
+    assert.equal(typeof sdk.nip44?.getConversationKey, 'function')
+    assert.equal(typeof sdk.verifyEvent, 'function')
+
+    const pool = new sdk.SimplePool()
+    assert.equal(typeof pool.subscribeMany, 'function')
+    assert.equal(typeof pool.publish, 'function')
+    pool.destroy?.()
+  })
+
+  it('round-trips a CLINK-shaped payload with SDK nip44', async () => {
+    const { nip44, generateSecretKey, getPublicKey } = await loadCurrentSdk()
+    const priv = generateSecretKey()
+    const peer = getPublicKey(generateSecretKey())
+    const payload = { offer: 'x', amount_sats: 21, description: 'compat' }
+    const ck = nip44.getConversationKey(priv, peer)
+    const cipher = nip44.encrypt(JSON.stringify(payload), ck)
+    const plain = JSON.parse(nip44.decrypt(cipher, ck))
+    assert.deepEqual(plain, payload)
+  })
+
+  it('keeps nostr-tools/lib/types/pool.d.ts available for deep type imports', () => {
+    const meta = readCompatMeta()
+    const poolDts = join(meta.currentTree, 'node_modules/nostr-tools/lib/types/pool.d.ts')
+    assert.equal(existsSync(poolDts), true, `missing ${poolDts}`)
+  })
+})
+
+describe('offline cross-decrypt current ↔ prior', () => {
+  it('A encrypt → B decrypt and reverse', async () => {
+    const current = await loadCurrentSdk()
+    const prior = await loadPriorAppModules()
+
+    const aPriv = current.generateSecretKey()
+    const bPriv = prior.generateSecretKey()
+    const aPub = current.getPublicKey(aPriv)
+    const bPub = prior.getPublicKey(bPriv)
+
+    const request = { offer: 'coffee', amount_sats: 1000 }
+    const aCipher = current.nip44.encrypt(
+      JSON.stringify(request),
+      current.nip44.getConversationKey(aPriv, bPub)
+    )
+    const aPlain = JSON.parse(
+      prior.nip44.decrypt(aCipher, prior.nip44.getConversationKey(bPriv, aPub))
+    )
+    assert.deepEqual(aPlain, request)
+
+    const reply = { bolt11: 'lnbc1dummyinvoice' }
+    const bCipher = prior.nip44.encrypt(
+      JSON.stringify(reply),
+      prior.nip44.getConversationKey(bPriv, aPub)
+    )
+    const bPlain = JSON.parse(
+      current.nip44.decrypt(bCipher, current.nip44.getConversationKey(aPriv, bPub))
+    )
+    assert.deepEqual(bPlain, reply)
+
+    assert.equal(
+      toHex(current.nip44.getConversationKey(aPriv, bPub)),
+      toHex(prior.nip44.getConversationKey(bPriv, aPub))
+    )
+  })
+})

--- a/test/compat/paths.mjs
+++ b/test/compat/paths.mjs
@@ -1,0 +1,83 @@
+import { createRequire } from 'node:module'
+import { existsSync, readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const repoRoot = resolve(__dirname, '../..')
+const defaultCompatRoot = join(repoRoot, 'test/fixtures/compat-trees')
+
+export function getCompatRoot() {
+  return resolve(process.env.COMPAT_ROOT || defaultCompatRoot)
+}
+
+/** Local hex helpers: compat trees must not depend on @noble/hashes subpaths. */
+export function toHex(bytes) {
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('')
+}
+
+export function fromHex(hex) {
+  const bytes = new Uint8Array(hex.length / 2)
+  for (let i = 0; i < bytes.length; i++) {
+    bytes[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16)
+  }
+  return bytes
+}
+
+export function readCompatMeta() {
+  const metaPath = join(getCompatRoot(), 'meta.json')
+  if (!existsSync(metaPath)) {
+    throw new Error(`compat trees missing (${metaPath}); run node test/compat/setup-trees.mjs first`)
+  }
+  return JSON.parse(readFileSync(metaPath, 'utf8'))
+}
+
+export async function loadCurrentSdk() {
+  const { currentTree } = readCompatMeta()
+  return import(pathToFileURL(join(currentTree, 'build/index.js')).href)
+}
+
+/**
+ * Emulate how 1.5.x apps use the SDK:
+ * - ClinkSDK / SimplePool from @shocknet/clink-sdk
+ * - nip44 / finalizeEvent from nested nostr-tools when SDK does not re-export them
+ */
+export async function loadPriorAppModules() {
+  const { priorTree, priorVersion } = readCompatMeta()
+  const sdkPkgJson = join(priorTree, 'node_modules/@shocknet/clink-sdk/package.json')
+  const sdkMain = join(priorTree, 'node_modules/@shocknet/clink-sdk/build/index.js')
+  if (!existsSync(sdkMain)) {
+    throw new Error(`prior SDK build missing at ${sdkMain}`)
+  }
+
+  const sdk = await import(pathToFileURL(sdkMain).href)
+  const requireFromSdk = createRequire(sdkPkgJson)
+
+  let nip44
+  let finalizeEvent
+  let getPublicKey
+  let generateSecretKey
+
+  if (typeof sdk.nip44?.encrypt === 'function' && typeof sdk.finalizeEvent === 'function') {
+    nip44 = sdk.nip44
+    finalizeEvent = sdk.finalizeEvent
+    getPublicKey = sdk.getPublicKey
+    generateSecretKey = sdk.generateSecretKey
+  } else {
+    const tools = requireFromSdk('nostr-tools')
+    nip44 = tools.nip44
+    finalizeEvent = tools.finalizeEvent
+    getPublicKey = tools.getPublicKey
+    generateSecretKey = tools.generateSecretKey
+  }
+
+  return {
+    priorVersion,
+    sdk,
+    SimplePool: sdk.SimplePool,
+    nip44,
+    finalizeEvent,
+    getPublicKey,
+    generateSecretKey,
+  }
+}

--- a/test/compat/relay-client.test.mjs
+++ b/test/compat/relay-client.test.mjs
@@ -1,0 +1,127 @@
+import { describe, it, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { spawn } from 'node:child_process'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { setTimeout as sleep } from 'node:timers/promises'
+import { loadCurrentSdk, readCompatMeta, toHex } from './paths.mjs'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const relayUrl = process.env.RELAY_URL || 'ws://127.0.0.1:7777'
+const receiptDelayMs = Number(process.env.RECEIPT_DELAY_MS || 2000)
+
+describe('strfry request/response A↔B', () => {
+  let serverPrivHex
+  let serverPub
+  let responder
+  let readyDir
+  let readyFile
+  let sdk
+  let generateSecretKey
+  let getPublicKey
+
+  before(async () => {
+    readCompatMeta()
+    sdk = await loadCurrentSdk()
+    generateSecretKey = sdk.generateSecretKey
+    getPublicKey = sdk.getPublicKey
+
+    const serverPriv = generateSecretKey()
+    serverPrivHex = toHex(serverPriv)
+    serverPub = getPublicKey(serverPriv)
+
+    readyDir = mkdtempSync(join(tmpdir(), 'clink-ready-'))
+    readyFile = join(readyDir, 'ready')
+
+    responder = spawn(process.execPath, [join(__dirname, 'relay-responder.mjs')], {
+      env: {
+        ...process.env,
+        RELAY_URL: relayUrl,
+        SERVER_NSEC_HEX: serverPrivHex,
+        RECEIPT_DELAY_MS: String(receiptDelayMs),
+        READY_FILE: readyFile,
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    responder.stdout.on('data', (d) => process.stdout.write(`[responder] ${d}`))
+    responder.stderr.on('data', (d) => process.stderr.write(`[responder] ${d}`))
+
+    const readyProc = spawn(
+      process.execPath,
+      [join(__dirname, 'wait-for-ready.mjs')],
+      {
+        env: { ...process.env, READY_FILE: readyFile, READY_WAIT_MS: '30000' },
+        stdio: 'inherit',
+      }
+    )
+    const code = await new Promise((resolve) => readyProc.on('close', resolve))
+    assert.equal(code, 0, 'responder did not reach EOSE in time')
+  })
+
+  after(() => {
+    responder?.kill('SIGTERM')
+    if (readyDir) rmSync(readyDir, { recursive: true, force: true })
+  })
+
+  it('noffer happy path returns dummy bolt11', async () => {
+    const client = new sdk.ClinkSDK({
+      privateKey: generateSecretKey(),
+      relays: [relayUrl],
+      toPubKey: serverPub,
+      defaultTimeoutSeconds: 15,
+    })
+    const response = await client.Noffer({ offer: 'test_offer', amount_sats: 21 })
+    assert.ok('bolt11' in response, `expected bolt11, got ${JSON.stringify(response)}`)
+    assert.match(response.bolt11, /^lnbc1/)
+  })
+
+  it('ndebit happy path returns ok', async () => {
+    const client = new sdk.ClinkSDK({
+      privateKey: generateSecretKey(),
+      relays: [relayUrl],
+      toPubKey: serverPub,
+      defaultTimeoutSeconds: 15,
+    })
+    const response = await client.Ndebit(
+      sdk.newNdebitPaymentRequest('lnbc1clientinvoice', 100, 'ptr')
+    )
+    assert.equal(response.res, 'ok')
+  })
+
+  it('fast-reply race still resolves', async () => {
+    const client = new sdk.ClinkSDK({
+      privateKey: generateSecretKey(),
+      relays: [relayUrl],
+      toPubKey: serverPub,
+      defaultTimeoutSeconds: 15,
+    })
+    const response = await client.Noffer({ offer: 'fast', amount_sats: 1 })
+    assert.ok('bolt11' in response)
+  })
+
+  it('receipt callback fires on delayed synthetic receipt', async () => {
+    const client = new sdk.ClinkSDK({
+      privateKey: generateSecretKey(),
+      relays: [relayUrl],
+      toPubKey: serverPub,
+      defaultTimeoutSeconds: 15,
+    })
+
+    let receipt = null
+    const primary = await client.Noffer(
+      { offer: 'with_receipt', amount_sats: 7 },
+      (r) => {
+        receipt = r
+      }
+    )
+    assert.ok('bolt11' in primary)
+
+    const deadline = Date.now() + receiptDelayMs + 10000
+    while (!receipt && Date.now() < deadline) {
+      await sleep(100)
+    }
+    assert.deepEqual(receipt, { res: 'ok' })
+  })
+})

--- a/test/compat/relay-client.test.mjs
+++ b/test/compat/relay-client.test.mjs
@@ -12,6 +12,15 @@ const __dirname = dirname(fileURLToPath(import.meta.url))
 const relayUrl = process.env.RELAY_URL || 'ws://127.0.0.1:7777'
 const receiptDelayMs = Number(process.env.RECEIPT_DELAY_MS || 2000)
 
+function killResponder(child) {
+  if (!child || child.killed) return
+  child.kill('SIGTERM')
+  // Force-exit if pool.destroy / WS close stalls
+  setTimeout(() => {
+    if (!child.killed) child.kill('SIGKILL')
+  }, 2000).unref()
+}
+
 describe('strfry request/response A↔B', () => {
   let serverPrivHex
   let serverPub
@@ -21,6 +30,18 @@ describe('strfry request/response A↔B', () => {
   let sdk
   let generateSecretKey
   let getPublicKey
+  const clients = []
+
+  function makeClient() {
+    const client = new sdk.ClinkSDK({
+      privateKey: generateSecretKey(),
+      relays: [relayUrl],
+      toPubKey: serverPub,
+      defaultTimeoutSeconds: 15,
+    })
+    clients.push(client)
+    return client
+  }
 
   before(async () => {
     readCompatMeta()
@@ -61,29 +82,26 @@ describe('strfry request/response A↔B', () => {
   })
 
   after(() => {
-    responder?.kill('SIGTERM')
+    for (const client of clients) {
+      try {
+        client.Stop()
+      } catch {
+        // ignore
+      }
+    }
+    killResponder(responder)
     if (readyDir) rmSync(readyDir, { recursive: true, force: true })
   })
 
   it('noffer happy path returns dummy bolt11', async () => {
-    const client = new sdk.ClinkSDK({
-      privateKey: generateSecretKey(),
-      relays: [relayUrl],
-      toPubKey: serverPub,
-      defaultTimeoutSeconds: 15,
-    })
+    const client = makeClient()
     const response = await client.Noffer({ offer: 'test_offer', amount_sats: 21 })
     assert.ok('bolt11' in response, `expected bolt11, got ${JSON.stringify(response)}`)
     assert.match(response.bolt11, /^lnbc1/)
   })
 
   it('ndebit happy path returns ok', async () => {
-    const client = new sdk.ClinkSDK({
-      privateKey: generateSecretKey(),
-      relays: [relayUrl],
-      toPubKey: serverPub,
-      defaultTimeoutSeconds: 15,
-    })
+    const client = makeClient()
     const response = await client.Ndebit(
       sdk.newNdebitPaymentRequest('lnbc1clientinvoice', 100, 'ptr')
     )
@@ -91,23 +109,13 @@ describe('strfry request/response A↔B', () => {
   })
 
   it('fast-reply race still resolves', async () => {
-    const client = new sdk.ClinkSDK({
-      privateKey: generateSecretKey(),
-      relays: [relayUrl],
-      toPubKey: serverPub,
-      defaultTimeoutSeconds: 15,
-    })
+    const client = makeClient()
     const response = await client.Noffer({ offer: 'fast', amount_sats: 1 })
     assert.ok('bolt11' in response)
   })
 
   it('receipt callback fires on delayed synthetic receipt', async () => {
-    const client = new sdk.ClinkSDK({
-      privateKey: generateSecretKey(),
-      relays: [relayUrl],
-      toPubKey: serverPub,
-      defaultTimeoutSeconds: 15,
-    })
+    const client = makeClient()
 
     let receipt = null
     const primary = await client.Noffer(

--- a/test/compat/relay-responder.mjs
+++ b/test/compat/relay-responder.mjs
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+/**
+ * Prior-SDK CLINK responder (emulates a 1.5.x app peer).
+ *
+ * Env:
+ *   RELAY_URL — default ws://127.0.0.1:7777
+ *   SERVER_NSEC_HEX — 64-hex private key (required)
+ *   RECEIPT_DELAY_MS — delay before synthetic receipt (default 10000)
+ *   READY_FILE — path written when subscription EOSE received
+ */
+import { writeFileSync } from 'node:fs'
+import { fromHex, loadPriorAppModules } from './paths.mjs'
+
+const relayUrl = process.env.RELAY_URL || 'ws://127.0.0.1:7777'
+const receiptDelayMs = Number(process.env.RECEIPT_DELAY_MS || 10000)
+const readyFile = process.env.READY_FILE
+const serverNsecHex = process.env.SERVER_NSEC_HEX
+
+if (!serverNsecHex || serverNsecHex.length !== 64) {
+  console.error('SERVER_NSEC_HEX (64 hex chars) required')
+  process.exit(1)
+}
+
+const prior = await loadPriorAppModules()
+const serverPriv = fromHex(serverNsecHex)
+const serverPub = prior.getPublicKey(serverPriv)
+const pool = new prior.SimplePool()
+
+console.log(`[responder] prior=${prior.priorVersion} pubkey=${serverPub} relay=${relayUrl}`)
+
+function buildPrimaryPayload(requestKind) {
+  if (requestKind === 21001) {
+    return { bolt11: 'lnbc1clinksdktestdummyinvoice0000000000000000000000000000000000000' }
+  }
+  if (requestKind === 21002) {
+    return { res: 'ok', preimage: '00'.repeat(32) }
+  }
+  return { res: 'ok', resource: 'offer', details: [] }
+}
+
+function publishEncrypted(toPub, requestId, kind, payload) {
+  const content = prior.nip44.encrypt(
+    JSON.stringify(payload),
+    prior.nip44.getConversationKey(serverPriv, toPub)
+  )
+  const event = prior.finalizeEvent(
+    {
+      kind,
+      created_at: Math.floor(Date.now() / 1000),
+      tags: [
+        ['p', toPub],
+        ['e', requestId],
+        ['clink_version', '1'],
+      ],
+      content,
+    },
+    serverPriv
+  )
+  return Promise.all(pool.publish([relayUrl], event))
+}
+
+let eoseSeen = false
+pool.subscribeMany(
+  [relayUrl],
+  [
+    {
+      kinds: [21001, 21002, 21003],
+      '#p': [serverPub],
+      since: Math.floor(Date.now() / 1000) - 5,
+    },
+  ],
+  {
+    oneose: () => {
+      if (eoseSeen) return
+      eoseSeen = true
+      console.log('[responder] EOSE — ready for requests')
+      if (readyFile) writeFileSync(readyFile, `${Date.now()}\n`)
+    },
+    onevent: async (event) => {
+      try {
+        const plain = JSON.parse(
+          prior.nip44.decrypt(
+            event.content,
+            prior.nip44.getConversationKey(serverPriv, event.pubkey)
+          )
+        )
+        console.log(`[responder] request kind=${event.kind} id=${event.id} body=`, plain)
+        await publishEncrypted(event.pubkey, event.id, event.kind, buildPrimaryPayload(event.kind))
+        console.log(`[responder] primary reply published for ${event.id}`)
+
+        if (event.kind === 21001) {
+          setTimeout(async () => {
+            try {
+              await publishEncrypted(event.pubkey, event.id, event.kind, { res: 'ok' })
+              console.log(`[responder] receipt published for ${event.id}`)
+            } catch (err) {
+              console.error('[responder] receipt publish failed', err)
+            }
+          }, receiptDelayMs)
+        }
+      } catch (err) {
+        console.error('[responder] failed to handle event', event.id, err)
+      }
+    },
+  }
+)
+
+process.on('SIGINT', () => {
+  pool.destroy?.()
+  process.exit(0)
+})

--- a/test/compat/relay-responder.mjs
+++ b/test/compat/relay-responder.mjs
@@ -105,7 +105,14 @@ pool.subscribeMany(
   }
 )
 
-process.on('SIGINT', () => {
-  pool.destroy?.()
+process.on('SIGINT', shutdown)
+process.on('SIGTERM', shutdown)
+
+function shutdown() {
+  try {
+    pool.destroy?.()
+  } catch {
+    // ignore
+  }
   process.exit(0)
-})
+}

--- a/test/compat/setup-trees.mjs
+++ b/test/compat/setup-trees.mjs
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+/**
+ * Materialize current + prior install trees for offline/relay compat tests.
+ *
+ * Env:
+ *   PRIOR_SDK_VERSION — override prior package version (default: npm view latest)
+ *   NOSTR_TOOLS_VERSION — optional candidate tools version for current tree
+ *   COMPAT_ROOT — output directory (default: test/fixtures/compat-trees)
+ */
+import { execFileSync } from 'node:child_process'
+import { cpSync, existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const repoRoot = resolve(__dirname, '../..')
+const compatRoot = resolve(process.env.COMPAT_ROOT || join(repoRoot, 'test/fixtures/compat-trees'))
+const currentTree = join(compatRoot, 'current')
+const priorTree = join(compatRoot, 'prior')
+
+function sh(cmd, args, opts = {}) {
+  const inherit = opts.stdio === 'inherit'
+  const result = execFileSync(cmd, args, {
+    encoding: inherit ? undefined : 'utf8',
+    stdio: inherit ? 'inherit' : ['ignore', 'pipe', 'pipe'],
+    ...opts,
+  })
+  if (inherit) return ''
+  return String(result).trim()
+}
+
+function resolvePriorVersion() {
+  if (process.env.PRIOR_SDK_VERSION) return process.env.PRIOR_SDK_VERSION
+  return sh('npm', ['view', '@shocknet/clink-sdk', 'version'], { cwd: repoRoot })
+}
+
+function prepareCurrentTree() {
+  rmSync(currentTree, { recursive: true, force: true })
+  mkdirSync(currentTree, { recursive: true })
+
+  // Isolated tree so candidate nostr-tools installs do not mutate the repo checkout.
+  for (const name of ['package.json', 'package-lock.json', 'build', 'src', 'tsconfig.json']) {
+    const src = join(repoRoot, name)
+    if (!existsSync(src)) throw new Error(`missing ${name}; run npm run prepack first`)
+    cpSync(src, join(currentTree, name), { recursive: true })
+  }
+
+  sh('npm', ['ci'], { cwd: currentTree, stdio: 'inherit' })
+
+  const candidate = process.env.NOSTR_TOOLS_VERSION
+  if (candidate) {
+    console.log(`[setup-trees] installing nostr-tools@${candidate} into current tree`)
+    sh('npm', ['install', '--no-save', `nostr-tools@${candidate}`], {
+      cwd: currentTree,
+      stdio: 'inherit',
+    })
+    // Candidate must typecheck/build (catches deep import breaks like lib/types/pool).
+    console.log(`[setup-trees] prepack against nostr-tools@${candidate}`)
+    sh('npm', ['run', 'prepack'], { cwd: currentTree, stdio: 'inherit' })
+  }
+}
+
+function preparePriorTree(version) {
+  rmSync(priorTree, { recursive: true, force: true })
+  mkdirSync(priorTree, { recursive: true })
+  writeFileSync(
+    join(priorTree, 'package.json'),
+    JSON.stringify(
+      {
+        name: 'clink-sdk-prior-tree',
+        private: true,
+        type: 'module',
+        dependencies: {
+          '@shocknet/clink-sdk': version,
+        },
+      },
+      null,
+      2
+    )
+  )
+  console.log(`[setup-trees] installing @shocknet/clink-sdk@${version} into prior tree`)
+  sh('npm', ['install'], { cwd: priorTree, stdio: 'inherit' })
+}
+
+const priorVersion = resolvePriorVersion()
+console.log(`[setup-trees] prior SDK version: ${priorVersion}`)
+prepareCurrentTree()
+preparePriorTree(priorVersion)
+
+writeFileSync(
+  join(compatRoot, 'meta.json'),
+  JSON.stringify(
+    {
+      priorVersion,
+      nostrToolsVersion: process.env.NOSTR_TOOLS_VERSION || null,
+      currentTree,
+      priorTree,
+      createdAt: new Date().toISOString(),
+    },
+    null,
+    2
+  )
+)
+
+console.log(`[setup-trees] ready under ${compatRoot}`)

--- a/test/compat/strfry.conf
+++ b/test/compat/strfry.conf
@@ -3,7 +3,8 @@
 ## (prod-like defaults; CI-safe mapsize/nofiles; bind all interfaces for Docker)
 ##
 
-db = "./strfry-db/"
+# Absolute path — dockurr image WORKDIR is /app; relative ./ can miss a writable LMDB dir
+db = "/app/strfry-db/"
 
 dbParams {
     maxreaders = 64

--- a/test/compat/strfry.conf
+++ b/test/compat/strfry.conf
@@ -1,0 +1,85 @@
+##
+## Minimal strfry config for ClinkSDK CI
+## (prod-like defaults; CI-safe mapsize/nofiles; bind all interfaces for Docker)
+##
+
+db = "./strfry-db/"
+
+dbParams {
+    maxreaders = 64
+    # Small mapsize for containers (prod uses 10TB)
+    mapsize = 1073741824
+    noReadAhead = true
+}
+
+events {
+    maxEventSize = 65536
+    rejectEventsNewerThanSeconds = 900
+    rejectEventsOlderThanSeconds = 94608000
+    # CLINK kinds 21001-21003 are ephemeral (20000-29999)
+    rejectEphemeralEventsOlderThanSeconds = 60
+    ephemeralEventsLifetimeSeconds = 300
+    maxNumTags = 2000
+    maxTagValSize = 1024
+}
+
+relay {
+    # 0.0.0.0 so GitHub Actions service port mapping works
+    bind = "0.0.0.0"
+    port = 7777
+    # Don't try to raise ulimit in CI
+    nofiles = 0
+    realIpHeader = ""
+
+    auth {
+        # CLINK clients do not perform NIP-42; recent strfry defaults this on
+        enabled = false
+        serviceUrl = ""
+    }
+
+    info {
+        name = "clink-sdk-ci"
+        description = "Local strfry for ClinkSDK compat tests"
+        pubkey = ""
+        contact = ""
+        icon = ""
+        nips = ""
+    }
+
+    maxWebsocketPayloadSize = 131072
+    maxReqFilterSize = 200
+    autoPingSeconds = 55
+    enableTcpKeepalive = false
+    queryTimesliceBudgetMicroseconds = 10000
+    maxFilterLimit = 500
+    maxSubsPerConnection = 50
+
+    writePolicy {
+        plugin = ""
+    }
+
+    compression {
+        enabled = true
+        slidingWindow = true
+    }
+
+    logging {
+        dumpInAll = false
+        dumpInEvents = false
+        dumpInReqs = false
+        dbScanPerf = false
+        invalidEvents = true
+    }
+
+    numThreads {
+        ingester = 1
+        reqWorker = 1
+        reqMonitor = 1
+        negentropy = 1
+    }
+
+    negentropy {
+        enabled = false
+        maxSyncEvents = 1000000
+    }
+}

--- a/test/compat/wait-for-ready.mjs
+++ b/test/compat/wait-for-ready.mjs
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+/** Poll until READY_FILE exists (responder EOSE). */
+import { existsSync } from 'node:fs'
+import { setTimeout as sleep } from 'node:timers/promises'
+
+const readyFile = process.env.READY_FILE
+const timeoutMs = Number(process.env.READY_WAIT_MS || 30000)
+if (!readyFile) {
+  console.error('READY_FILE required')
+  process.exit(1)
+}
+
+const started = Date.now()
+while (Date.now() - started < timeoutMs) {
+  if (existsSync(readyFile)) {
+    console.log(`[wait-for-ready] ${readyFile}`)
+    process.exit(0)
+  }
+  await sleep(100)
+}
+
+console.error(`[wait-for-ready] timed out waiting for ${readyFile}`)
+process.exit(1)

--- a/test/compat/wait-for-relay.mjs
+++ b/test/compat/wait-for-relay.mjs
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+/** Wait until RELAY_URL accepts a WebSocket connection. */
+import { setTimeout as sleep } from 'node:timers/promises'
+
+const relayUrl = process.env.RELAY_URL || 'ws://127.0.0.1:7777'
+const timeoutMs = Number(process.env.RELAY_WAIT_MS || 60000)
+const started = Date.now()
+
+while (Date.now() - started < timeoutMs) {
+  try {
+    await new Promise((resolve, reject) => {
+      const ws = new WebSocket(relayUrl)
+      const timer = setTimeout(() => {
+        ws.close()
+        reject(new Error('connect timeout'))
+      }, 3000)
+      ws.addEventListener('open', () => {
+        clearTimeout(timer)
+        ws.close()
+        resolve()
+      })
+      ws.addEventListener('error', (err) => {
+        clearTimeout(timer)
+        reject(err)
+      })
+    })
+    console.log(`[wait-for-relay] ready: ${relayUrl}`)
+    process.exit(0)
+  } catch {
+    await sleep(500)
+  }
+}
+
+console.error(`[wait-for-relay] timed out waiting for ${relayUrl}`)
+process.exit(1)

--- a/test/fixtures/bech32.json
+++ b/test/fixtures/bech32.json
@@ -1,0 +1,27 @@
+{
+  "noffer": {
+    "encoded": "noffer1qszqqqqraqpszqqzp9hkven9wf0kzcnrqythwumn8ghj7un9d3shjtn90psk6urvv5hxxmmdqqs8rdct4njgvlyqhe4ss02ynsm5smen0yxlp6jthehfeeshhm35kes9yppf9",
+    "decoded": {
+      "pubkey": "71b70bace4867c80be6b083d449c37486f33790df0ea4bbe6e9ce617bee34b66",
+      "relay": "wss://relay.example.com",
+      "offer": "offer_abc",
+      "priceType": 0,
+      "price": 1000
+    }
+  },
+  "ndebit": {
+    "encoded": "ndebit1qgy8xar0wfj47dpjqythwumn8ghj7un9d3shjtn90psk6urvv5hxxmmdqqs8rdct4njgvlyqhe4ss02ynsm5smen0yxlp6jthehfeeshhm35kesh4xxz5",
+    "decoded": {
+      "pubkey": "71b70bace4867c80be6b083d449c37486f33790df0ea4bbe6e9ce617bee34b66",
+      "relay": "wss://relay.example.com",
+      "pointer": "store_42"
+    }
+  },
+  "nmanage": {
+    "decoded": {
+      "pubkey": "71b70bace4867c80be6b083d449c37486f33790df0ea4bbe6e9ce617bee34b66",
+      "relay": "wss://relay.example.com",
+      "pointer": "store_42"
+    }
+  }
+}

--- a/test/fixtures/bech32.json
+++ b/test/fixtures/bech32.json
@@ -17,6 +17,15 @@
       "pointer": "store_42"
     }
   },
+  "ndebit_with_k1": {
+    "encoded": "ndebit1qvsqzg69v7y6hn00qy352euf40x77qfrg4ncn27dauqjx3t83x4ummczppehgmmjv40ngvspzamhxue69uhhyetvv9ujuetcv9khqmr99e3k7mgqypcmwzavujr8eq97dvyr63yuxayx7vmephcw5ja7d6wwv9a7ud9kvg6dys8",
+    "decoded": {
+      "pubkey": "71b70bace4867c80be6b083d449c37486f33790df0ea4bbe6e9ce617bee34b66",
+      "relay": "wss://relay.example.com",
+      "pointer": "store_42",
+      "k1": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+    }
+  },
   "nmanage": {
     "decoded": {
       "pubkey": "71b70bace4867c80be6b083d449c37486f33790df0ea4bbe6e9ce617bee34b66",

--- a/test/unit/bech32.test.mjs
+++ b/test/unit/bech32.test.mjs
@@ -1,0 +1,55 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+import {
+  decodeBech32,
+  nofferEncode,
+  ndebitEncode,
+  nmanageEncode,
+  OfferPriceType,
+} from '../../build/index.js'
+
+const fixtures = JSON.parse(
+  readFileSync(join(dirname(fileURLToPath(import.meta.url)), '../fixtures/bech32.json'), 'utf8')
+)
+
+describe('bech32 round-trip', () => {
+  it('decodes and re-encodes noffer fixture', () => {
+    const { encoded, decoded } = fixtures.noffer
+    const result = decodeBech32(encoded)
+    assert.equal(result.type, 'noffer')
+    assert.equal(result.data.pubkey, decoded.pubkey)
+    assert.equal(result.data.relay, decoded.relay)
+    assert.equal(result.data.offer, decoded.offer)
+    assert.equal(result.data.priceType, decoded.priceType)
+    assert.equal(result.data.price, decoded.price)
+
+    const reencoded = nofferEncode({
+      ...decoded,
+      priceType: OfferPriceType.Fixed,
+    })
+    assert.equal(reencoded, encoded)
+  })
+
+  it('decodes and re-encodes ndebit fixture', () => {
+    const { encoded, decoded } = fixtures.ndebit
+    const result = decodeBech32(encoded)
+    assert.equal(result.type, 'ndebit')
+    assert.equal(result.data.pubkey, decoded.pubkey)
+    assert.equal(result.data.relay, decoded.relay)
+    assert.equal(result.data.pointer, decoded.pointer)
+    assert.equal(ndebitEncode(decoded), encoded)
+  })
+
+  it('round-trips nmanage encode/decode', () => {
+    const { decoded } = fixtures.nmanage
+    const encoded = nmanageEncode(decoded)
+    const result = decodeBech32(encoded)
+    assert.equal(result.type, 'nmanage')
+    assert.equal(result.data.pubkey, decoded.pubkey)
+    assert.equal(result.data.relay, decoded.relay)
+    assert.equal(result.data.pointer, decoded.pointer)
+  })
+})

--- a/test/unit/bech32.test.mjs
+++ b/test/unit/bech32.test.mjs
@@ -40,7 +40,20 @@ describe('bech32 round-trip', () => {
     assert.equal(result.data.pubkey, decoded.pubkey)
     assert.equal(result.data.relay, decoded.relay)
     assert.equal(result.data.pointer, decoded.pointer)
+    assert.equal(result.data.k1, undefined)
     assert.equal(ndebitEncode(decoded), encoded)
+  })
+
+  it('round-trips ndebit with session k1 (TLV 3)', () => {
+    const { encoded, decoded } = fixtures.ndebit_with_k1
+    assert.equal(ndebitEncode(decoded), encoded)
+    const result = decodeBech32(encoded)
+    assert.equal(result.type, 'ndebit')
+    assert.equal(result.data.pubkey, decoded.pubkey)
+    assert.equal(result.data.relay, decoded.relay)
+    assert.equal(result.data.pointer, decoded.pointer)
+    assert.equal(result.data.k1, decoded.k1)
+    assert.equal(ndebitEncode(result.data), encoded)
   })
 
   it('round-trips nmanage encode/decode', () => {

--- a/test/unit/builders.test.mjs
+++ b/test/unit/builders.test.mjs
@@ -20,6 +20,17 @@ describe('request builders', () => {
     })
   })
 
+  it('builds ndebit payment request with k1', () => {
+    const k1 = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
+    assert.deepEqual(newNdebitPaymentRequest('lnbc1test', 5000, 'ptr', k1), {
+      bolt11: 'lnbc1test',
+      amount_sats: 5000,
+      pointer: 'ptr',
+      k1,
+    })
+    assert.throws(() => newNdebitPaymentRequest('lnbc1test', 5000, 'ptr', 'not-a-k1'))
+  })
+
   it('builds ndebit full access request', () => {
     assert.deepEqual(newNdebitFullAccessRequest('ptr'), { pointer: 'ptr' })
   })

--- a/test/unit/builders.test.mjs
+++ b/test/unit/builders.test.mjs
@@ -31,6 +31,18 @@ describe('request builders', () => {
     assert.throws(() => newNdebitPaymentRequest('lnbc1test', 5000, 'ptr', 'not-a-k1'))
   })
 
+  it('builds ndebit payment request with description', () => {
+    assert.deepEqual(newNdebitPaymentRequest('lnbc1test', 5000, 'ptr', undefined, 'coffee'), {
+      bolt11: 'lnbc1test',
+      amount_sats: 5000,
+      pointer: 'ptr',
+      description: 'coffee',
+    })
+    assert.throws(() =>
+      newNdebitPaymentRequest('lnbc1test', 5000, 'ptr', undefined, 'x'.repeat(101))
+    )
+  })
+
   it('builds ndebit full access request', () => {
     assert.deepEqual(newNdebitFullAccessRequest('ptr'), { pointer: 'ptr' })
   })
@@ -41,6 +53,18 @@ describe('request builders', () => {
       frequency: { number: 1, unit: 'week' },
       pointer: 'ptr',
     })
+  })
+
+  it('builds ndebit budget request with description', () => {
+    assert.deepEqual(
+      newNdebitBudgetRequest({ number: 1, unit: 'week' }, 1000, 'ptr', 'weekly coffee'),
+      {
+        amount_sats: 1000,
+        frequency: { number: 1, unit: 'week' },
+        pointer: 'ptr',
+        description: 'weekly coffee',
+      }
+    )
   })
 
   it('builds nmanage helpers', () => {

--- a/test/unit/builders.test.mjs
+++ b/test/unit/builders.test.mjs
@@ -1,0 +1,68 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  newNdebitPaymentRequest,
+  newNdebitFullAccessRequest,
+  newNdebitBudgetRequest,
+  newCreateRequest,
+  newUpdateRequest,
+  newDeleteRequest,
+  newGetRequest,
+  newListRequest,
+} from '../../build/index.js'
+
+describe('request builders', () => {
+  it('builds ndebit payment request', () => {
+    assert.deepEqual(newNdebitPaymentRequest('lnbc1test', 5000, 'ptr'), {
+      bolt11: 'lnbc1test',
+      amount_sats: 5000,
+      pointer: 'ptr',
+    })
+  })
+
+  it('builds ndebit full access request', () => {
+    assert.deepEqual(newNdebitFullAccessRequest('ptr'), { pointer: 'ptr' })
+  })
+
+  it('builds ndebit budget request', () => {
+    assert.deepEqual(newNdebitBudgetRequest({ number: 1, unit: 'week' }, 1000, 'ptr'), {
+      amount_sats: 1000,
+      frequency: { number: 1, unit: 'week' },
+      pointer: 'ptr',
+    })
+  })
+
+  it('builds nmanage helpers', () => {
+    assert.deepEqual(newListRequest('ptr'), {
+      resource: 'offer',
+      action: 'list',
+      pointer: 'ptr',
+    })
+    assert.deepEqual(newGetRequest('offer1'), {
+      resource: 'offer',
+      action: 'get',
+      offer: { id: 'offer1' },
+    })
+    assert.deepEqual(newDeleteRequest('offer1'), {
+      resource: 'offer',
+      action: 'delete',
+      offer: { id: 'offer1' },
+    })
+    const created = newCreateRequest('coffee', { price_sats: 21 }, 'ptr')
+    assert.equal(created.action, 'create')
+    assert.equal(created.offer.fields.label, 'coffee')
+    assert.equal(created.offer.fields.price_sats, 21)
+    assert.equal(created.pointer, 'ptr')
+
+    const updated = newUpdateRequest({
+      id: 'offer1',
+      label: 'tea',
+      price_sats: 42,
+      callback_url: '',
+      payer_data: [],
+    })
+    assert.equal(updated.action, 'update')
+    assert.equal(updated.offer.id, 'offer1')
+    assert.equal(updated.offer.fields.label, 'tea')
+  })
+})

--- a/test/unit/sender.test.mjs
+++ b/test/unit/sender.test.mjs
@@ -1,0 +1,212 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { generateSecretKey, getPublicKey, nip44 } from 'nostr-tools'
+import { sendRequest } from '../../build/sender.js'
+
+const { getConversationKey, encrypt } = nip44
+
+function makeEncryptedReply(serverPriv, clientPub, payload) {
+  return encrypt(JSON.stringify(payload), getConversationKey(serverPriv, clientPub))
+}
+
+function createMockPool({ onSubscribe, onPublish, replyFactory }) {
+  let publishCalled = false
+  let subscribeCalled = false
+  let closed = false
+  let onevent = null
+  const order = []
+
+  return {
+    order,
+    wasClosed: () => closed,
+    subscribeMany(relays, filters, opts) {
+      subscribeCalled = true
+      order.push('subscribe')
+      assert.equal(publishCalled, false, 'subscribe must happen before publish')
+      onSubscribe?.(relays, filters, opts)
+      onevent = opts.onevent
+      return {
+        close: () => {
+          closed = true
+          order.push('close')
+        },
+      }
+    },
+    publish(relays, event) {
+      publishCalled = true
+      order.push('publish')
+      assert.equal(subscribeCalled, true, 'publish must happen after subscribe')
+      onPublish?.(relays, event)
+      const replies = replyFactory?.(event, onevent) ?? []
+      for (const reply of replies) {
+        queueMicrotask(() => onevent(reply))
+      }
+      return [Promise.resolve('ok')]
+    },
+  }
+}
+
+describe('sender lifecycle', () => {
+  it('subscribes before publish and resolves primary response', async () => {
+    const clientPriv = generateSecretKey()
+    const clientPub = getPublicKey(clientPriv)
+    const serverPriv = generateSecretKey()
+    const serverPub = getPublicKey(serverPriv)
+
+    const pool = createMockPool({
+      replyFactory: () => [
+        {
+          id: 'reply1',
+          kind: 21001,
+          pubkey: serverPub,
+          content: makeEncryptedReply(serverPriv, clientPub, { bolt11: 'lnbc1dummy' }),
+        },
+      ],
+    })
+
+    const result = await sendRequest(
+      pool,
+      { privateKey: clientPriv, publicKey: clientPub },
+      ['wss://relay.example.com'],
+      serverPub,
+      {
+        kind: 21001,
+        created_at: Math.floor(Date.now() / 1000),
+        tags: [['p', serverPub]],
+        content: 'unused',
+        pubkey: clientPub,
+      },
+      21001,
+      5
+    )
+
+    assert.deepEqual(result, { bolt11: 'lnbc1dummy' })
+    assert.deepEqual(pool.order.slice(0, 2), ['subscribe', 'publish'])
+    assert.equal(pool.wasClosed(), true)
+  })
+
+  it('keeps subscription open for moreCb until second event', async () => {
+    const clientPriv = generateSecretKey()
+    const clientPub = getPublicKey(clientPriv)
+    const serverPriv = generateSecretKey()
+    const serverPub = getPublicKey(serverPriv)
+
+    let onevent = null
+    const pool = createMockPool({
+      onSubscribe: (_r, _f, opts) => {
+        onevent = opts.onevent
+      },
+      replyFactory: () => [
+        {
+          id: 'primary',
+          kind: 21001,
+          pubkey: serverPub,
+          content: makeEncryptedReply(serverPriv, clientPub, { bolt11: 'lnbc1dummy' }),
+        },
+      ],
+    })
+
+    let receipt = null
+    const primary = await sendRequest(
+      pool,
+      { privateKey: clientPriv, publicKey: clientPub },
+      ['wss://relay.example.com'],
+      serverPub,
+      {
+        kind: 21001,
+        created_at: Math.floor(Date.now() / 1000),
+        tags: [['p', serverPub]],
+        content: 'unused',
+        pubkey: clientPub,
+      },
+      21001,
+      5,
+      (data) => {
+        receipt = data
+      }
+    )
+
+    assert.deepEqual(primary, { bolt11: 'lnbc1dummy' })
+    assert.equal(pool.wasClosed(), false)
+
+    await onevent({
+      id: 'receipt',
+      kind: 21001,
+      pubkey: serverPub,
+      content: makeEncryptedReply(serverPriv, clientPub, { res: 'ok' }),
+    })
+
+    assert.deepEqual(receipt, { res: 'ok' })
+    assert.equal(pool.wasClosed(), true)
+  })
+
+  it('rejects on decrypt failure', async () => {
+    const clientPriv = generateSecretKey()
+    const clientPub = getPublicKey(clientPriv)
+    const serverPub = getPublicKey(generateSecretKey())
+    const otherPriv = generateSecretKey()
+
+    const pool = createMockPool({
+      replyFactory: () => [
+        {
+          id: 'bad',
+          kind: 21001,
+          pubkey: serverPub,
+          content: makeEncryptedReply(otherPriv, clientPub, { bolt11: 'nope' }),
+        },
+      ],
+    })
+
+    await assert.rejects(
+      () =>
+        sendRequest(
+          pool,
+          { privateKey: clientPriv, publicKey: clientPub },
+          ['wss://relay.example.com'],
+          serverPub,
+          {
+            kind: 21001,
+            created_at: Math.floor(Date.now() / 1000),
+            tags: [['p', serverPub]],
+            content: 'unused',
+            pubkey: clientPub,
+          },
+          21001,
+          5
+        ),
+      /./
+    )
+    assert.equal(pool.wasClosed(), true)
+  })
+
+  it('rejects on timeout', async () => {
+    const clientPriv = generateSecretKey()
+    const clientPub = getPublicKey(clientPriv)
+    const serverPub = getPublicKey(generateSecretKey())
+
+    const pool = createMockPool({
+      replyFactory: () => [],
+    })
+
+    await assert.rejects(
+      () =>
+        sendRequest(
+          pool,
+          { privateKey: clientPriv, publicKey: clientPub },
+          ['wss://relay.example.com'],
+          serverPub,
+          {
+            kind: 21001,
+            created_at: Math.floor(Date.now() / 1000),
+            tags: [['p', serverPub]],
+            content: 'unused',
+            pubkey: clientPub,
+          },
+          21001,
+          0.05
+        ),
+      /failed to get response in time/
+    )
+    assert.equal(pool.wasClosed(), true)
+  })
+})

--- a/test/unit/sender.test.mjs
+++ b/test/unit/sender.test.mjs
@@ -1,9 +1,24 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
 import { generateSecretKey, getPublicKey, nip44 } from 'nostr-tools'
-import { sendRequest } from '../../build/sender.js'
+import { sendRequest, setDebug } from '../../build/sender.js'
 
 const { getConversationKey, encrypt } = nip44
+
+async function captureConsole(fn) {
+  const lines = []
+  const originalLog = console.log
+  const originalError = console.error
+  console.log = (...args) => lines.push(args.join(' '))
+  console.error = (...args) => lines.push(args.join(' '))
+  try {
+    await fn()
+  } finally {
+    console.log = originalLog
+    console.error = originalError
+  }
+  return lines
+}
 
 function makeEncryptedReply(serverPriv, clientPub, payload) {
   return encrypt(JSON.stringify(payload), getConversationKey(serverPriv, clientPub))
@@ -224,6 +239,43 @@ describe('sender lifecycle', () => {
     assert.equal(pool.wasClosed(), true)
   })
 
+  it('matches peer pubkey case-insensitively', async () => {
+    const clientPriv = generateSecretKey()
+    const clientPub = getPublicKey(clientPriv)
+    const serverPriv = generateSecretKey()
+    const serverPub = getPublicKey(serverPriv)
+
+    const pool = createMockPool({
+      replyFactory: () => [
+        {
+          id: 'reply1',
+          kind: 21001,
+          pubkey: serverPub,
+          content: makeEncryptedReply(serverPriv, clientPub, { bolt11: 'lnbc1dummy' }),
+        },
+      ],
+    })
+
+    const result = await sendRequest(
+      pool,
+      { privateKey: clientPriv, publicKey: clientPub },
+      ['wss://relay.example.com'],
+      serverPub.toUpperCase(),
+      {
+        kind: 21001,
+        created_at: Math.floor(Date.now() / 1000),
+        tags: [['p', serverPub]],
+        content: 'unused',
+        pubkey: clientPub,
+      },
+      21001,
+      5
+    )
+
+    assert.deepEqual(result, { bolt11: 'lnbc1dummy' })
+    assert.equal(pool.wasClosed(), true)
+  })
+
   it('rejects on timeout', async () => {
     const clientPriv = generateSecretKey()
     const clientPub = getPublicKey(clientPriv)
@@ -253,5 +305,47 @@ describe('sender lifecycle', () => {
       /failed to get response in time/
     )
     assert.equal(pool.wasClosed(), true)
+  })
+})
+
+describe('debug logging', () => {
+  const clientPriv = generateSecretKey()
+  const clientPub = getPublicKey(clientPriv)
+  const serverPub = getPublicKey(generateSecretKey())
+  const request = {
+    kind: 21001,
+    created_at: Math.floor(Date.now() / 1000),
+    tags: [['p', serverPub]],
+    content: 'unused',
+    pubkey: clientPub,
+  }
+
+  const sendAndTimeout = () =>
+    sendRequest(
+      createMockPool({ replyFactory: () => [] }),
+      { privateKey: clientPriv, publicKey: clientPub },
+      ['wss://relay.example.com'],
+      serverPub,
+      request,
+      21001,
+      0.05
+    ).catch(() => {})
+
+  it('is silent by default', async () => {
+    const lines = await captureConsole(sendAndTimeout)
+    assert.deepEqual(lines, [])
+  })
+
+  it('logs lifecycle when enabled, and stops when disabled again', async () => {
+    setDebug(true)
+    const loud = await captureConsole(sendAndTimeout)
+    setDebug(false)
+    const quiet = await captureConsole(sendAndTimeout)
+
+    assert.ok(
+      loud.some((line) => line.includes('[ClinkSDK]')),
+      'expected ClinkSDK lifecycle logs when debug enabled'
+    )
+    assert.deepEqual(quiet, [])
   })
 })

--- a/test/unit/sender.test.mjs
+++ b/test/unit/sender.test.mjs
@@ -140,7 +140,7 @@ describe('sender lifecycle', () => {
     assert.equal(pool.wasClosed(), true)
   })
 
-  it('rejects on decrypt failure', async () => {
+  it('rejects on decrypt failure from expected peer', async () => {
     const clientPriv = generateSecretKey()
     const clientPub = getPublicKey(clientPriv)
     const serverPub = getPublicKey(generateSecretKey())
@@ -176,6 +176,51 @@ describe('sender lifecycle', () => {
         ),
       /./
     )
+    assert.equal(pool.wasClosed(), true)
+  })
+
+  it('ignores forged non-peer events and still resolves the real reply', async () => {
+    const clientPriv = generateSecretKey()
+    const clientPub = getPublicKey(clientPriv)
+    const serverPriv = generateSecretKey()
+    const serverPub = getPublicKey(serverPriv)
+    const attackerPriv = generateSecretKey()
+    const attackerPub = getPublicKey(attackerPriv)
+
+    const pool = createMockPool({
+      replyFactory: () => [
+        {
+          id: 'forged',
+          kind: 21001,
+          pubkey: attackerPub,
+          content: 'not-valid-nip44',
+        },
+        {
+          id: 'reply1',
+          kind: 21001,
+          pubkey: serverPub,
+          content: makeEncryptedReply(serverPriv, clientPub, { bolt11: 'lnbc1dummy' }),
+        },
+      ],
+    })
+
+    const result = await sendRequest(
+      pool,
+      { privateKey: clientPriv, publicKey: clientPub },
+      ['wss://relay.example.com'],
+      serverPub,
+      {
+        kind: 21001,
+        created_at: Math.floor(Date.now() / 1000),
+        tags: [['p', serverPub]],
+        content: 'unused',
+        pubkey: clientPub,
+      },
+      21001,
+      5
+    )
+
+    assert.deepEqual(result, { bolt11: 'lnbc1dummy' })
     assert.equal(pool.wasClosed(), true)
   })
 

--- a/test/unit/validators.test.mjs
+++ b/test/unit/validators.test.mjs
@@ -1,0 +1,80 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  validateK1,
+  generateK1,
+  validateBudgetFrequency,
+  validateNdebitData,
+  validateNofferData,
+  validateNmanageRequest,
+  validateOfferFields,
+  newCreateRequest,
+  newListRequest,
+  newGetRequest,
+} from '../../build/index.js'
+
+describe('validators', () => {
+  it('validates k1', () => {
+    const k1 = generateK1()
+    assert.equal(validateK1(k1), k1)
+    assert.throws(() => validateK1(k1.toUpperCase()))
+    assert.throws(() => validateK1('short'))
+  })
+
+  it('validates budget frequency', () => {
+    assert.deepEqual(validateBudgetFrequency({ number: 1, unit: 'week' }), {
+      number: 1,
+      unit: 'week',
+    })
+    assert.throws(() => validateBudgetFrequency({ number: 0, unit: 'week' }))
+    assert.throws(() => validateBudgetFrequency({ number: 1.5, unit: 'week' }))
+    assert.throws(() => validateBudgetFrequency({ number: 1, unit: 'year' }))
+  })
+
+  it('validates ndebit data including description and k1', () => {
+    const k1 = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
+    assert.deepEqual(
+      validateNdebitData({ bolt11: 'lnbc1', amount_sats: 21, pointer: 'p', k1, description: 'coffee' }),
+      { bolt11: 'lnbc1', amount_sats: 21, pointer: 'p', k1, description: 'coffee' }
+    )
+    assert.throws(() => validateNdebitData({ bolt11: 1 }))
+    assert.throws(() => validateNdebitData({ description: 'x'.repeat(101) }))
+    assert.throws(() => validateNdebitData({ k1: 'bad' }))
+  })
+
+  it('validates noffer data', () => {
+    assert.deepEqual(validateNofferData({ offer: 'o', amount_sats: 21 }), {
+      offer: 'o',
+      amount_sats: 21,
+    })
+    assert.throws(() => validateNofferData({}))
+    assert.throws(() => validateNofferData({ offer: 'o', payer_data: [] }))
+    assert.doesNotThrow(() =>
+      validateNofferData({ offer: 'o', payer_data: { name: 'bob' } })
+    )
+  })
+
+  it('validates nmanage requests by action', () => {
+    const created = newCreateRequest('coffee', { price_sats: 21 }, 'ptr')
+    assert.deepEqual(validateNmanageRequest(created), created)
+    assert.deepEqual(validateNmanageRequest(newListRequest('ptr')), {
+      resource: 'offer',
+      action: 'list',
+      pointer: 'ptr',
+    })
+    assert.deepEqual(validateNmanageRequest(newGetRequest('id1')), {
+      resource: 'offer',
+      action: 'get',
+      offer: { id: 'id1' },
+    })
+    assert.throws(() => validateNmanageRequest({ resource: 'offer', action: 'explode' }))
+    assert.throws(() =>
+      validateOfferFields({
+        label: 'x',
+        price_sats: 1,
+        callback_url: '',
+        payer_data: [1],
+      })
+    )
+  })
+})


### PR DESCRIPTION
## Summary

Release prep for `@shocknet/clink-sdk` **1.6.0**: safer dependency usage for apps, session ndebit support per the CLINK Debits spec, request validators (ported from #17), and a real CI suite so `nostr-tools` upgrades don't land blind.

### Consumer / API

- **Re-export** `finalizeEvent`, `nip44`, `verifyEvent`, and pool types from the SDK's pinned `nostr-tools`. Apps should import these from `@shocknet/clink-sdk` and **not** install a second `nostr-tools` (common cause of decrypt failures / missed responses).
- **Sender lifecycle** fixes: subscribe before publish, reject on decrypt/parse failure instead of hanging, ignore non-peer events (anti-DoS), keep the sub open for Noffer receipts (`moreCb`) then close after the receipt, `ClinkSDK.Stop()` to destroy the pool.
- Peer pubkey compare is **case-insensitive** (`toPubKey` normalized to lowercase hex).
- Verbose relay lifecycle logs are opt-in via **`setDebug(true)`** (default off).
- **Session ndebits (`k1`)** per [CLINK Debits](https://github.com/shocknet/CLINK/blob/master/specs/clink-debits.md):
  - Optional TLV `3` on `DebitPointer` / `ndebitEncode` / `decodeBech32`
  - `generateK1()` / `validateK1()` (documented + exported; also `ClinkSDK.validateK1`)
  - `newNdebitPaymentRequest(..., k1?, description?)`
- Optional **`description`** on payment and budget builders (`newNdebitPaymentRequest` / `newNdebitBudgetRequest`, max 100 chars — same rule as noffer).
- **Request validators** (from closed #17 / `k1-and-validators`): `validateNofferData`, `validateNdebitData`, `validateBudgetFrequency`, `validateNmanageRequest` + per-action nmanage helpers / `validateOfferFields`. Intended for inbound payload checks (e.g. server-side).
- `NofferData.payer_data` typed as `Record<string, string>` (was `any`).
- Docs: troubleshooting guide, README debit/session/validator examples, language-port vectors in `test-vectors/interop.json` (including TLV `3`).

### CI / quality

- Unit tests for bech32 (incl. session `k1`), request builders (incl. `description`), validators, and mocked sender lifecycle (incl. case-insensitive peer + debug logging).
- Offline compat: current SDK ↔ prior published SDK nip44 cross-decrypt, plus candidate `nostr-tools` override path.
- Relay ping-pong against local **strfry** (current client ↔ prior-SDK responder, dummy invoice + delayed synthetic receipt).
- Weekly poll workflow (Mondays UTC): if registry `nostr-tools` > pin, run the suite and open a bump PR only when green (else a tracking issue). **Activates only after this merges to `main`** (scheduled workflows run from the default branch). Pin today is `2.15.1`; registry is already at `2.24.1`.
- npm publish waits for a successful CI run on `main` (`workflow_run`).
- README CI badge.

## Test plan

- [x] `npm test` (unit) green locally
- [x] `npm run test:compat-offline` green
- [x] CI Actions run on this PR: unit + compat-offline + compat-relay
- [x] Confirm session ndebit round-trip: encode with `generateK1()`, decode, payment request carries matching `k1`
- [x] Confirm static (no-`k1`) ndebit strings still decode/encode unchanged
- [x] Confirm request validators from #17 are exported and covered by unit tests
- [ ] After merge: badge + publish gate both keyed off CI on `main`
- [ ] After merge: nostr-tools poll runs (or manual dispatch) and opens bump/tracking for `2.24.1`
