### PR TITLE
feat: enroll-beacon

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@
   - [1. Encoding/Decoding Offers and Debits](#1-encodingdecoding-offers-and-debits)
   - [2. Sending a CLINK Offer Request (Lightning Invoice)](#2-sending-a-clink-offer-request-lightning-invoice)
   - [3. Sending a CLINK Debit Request](#3-sending-a-clink-debit-request)
+  - [4. Beacon](#4-beacon)
+  - [5. Enroll](#5-enroll)
 - [API Reference](#api-reference)
   - [ClinkSDK](#clinksdk)
   - [Encoding/Decoding](#encodingdecoding)
@@ -40,7 +42,8 @@
 ## Features
 
 - Encode/decode CLINK Static Offers (`noffer1...`) and Debits (`ndebit1...`) per the spec.
-- Send and receive CLINK payment requests (kind 21001) and debit requests (kind 21002) over Nostr.
+- Send CLINK offer (21001), debit (21002), manage (21003), and enroll (21004) requests.
+- Fetch a node `clink-node` beacon (kind 30078) for liveness, display, fees, and advertised kinds.
 - NIP-44 encrypted payloads for privacy and security.
 - TypeScript types for all protocol payloads and responses.
 - Simple, high-level API for wallet and service integration.
@@ -202,6 +205,41 @@ sdk.Ndebit(budgetRequest).then(response => {
 });
 ```
 
+### 4. Beacon
+
+Optional. Useful for rich display of node persona (name, avatar, fees, kinds). Recommended for the enroll fast-path: mine at `enroll_difficulty` instead of probing.
+
+```ts
+import { ClinkSDK, generateSecretKey } from '@shocknet/clink-sdk';
+
+const sdk = ClinkSDK.fromNprofile('nprofile1...', generateSecretKey());
+const beacon = await sdk.Nbeacon();
+if (!beacon) throw new Error('no beacon');
+
+console.log(beacon.content.name, beacon.content.fees, beacon.content.supported_kinds);
+sdk.Stop();
+```
+
+### 5. Enroll
+
+Enroll binds your signing key to an account and returns that account's `noffer` / `ndebit` / `nmanage`.
+
+```ts
+import { ClinkSDK, generateSecretKey, decodeBech32 } from '@shocknet/clink-sdk';
+
+const sdk = ClinkSDK.fromNprofile('nprofile1...', generateSecretKey());
+const enrolled = await sdk.Nenroll();
+if (enrolled.res !== 'ok') throw new Error(enrolled.error);
+
+const noffer = decodeBech32(enrolled.noffer);
+if (noffer.type !== 'noffer') throw new Error('expected noffer');
+const invoice = await sdk.Noffer({ offer: noffer.data.offer, amount_sats: 21 });
+
+sdk.Stop();
+```
+
+`Nenroll()` with no args uses a fresh beacon's `enroll_difficulty` when present, otherwise probes and remine once on GFY `5`. Pass `{ difficulty: 0 }` to probe, or `{ difficulty: 18 }` to skip the lookup.
+
 ---
 
 ## API Reference
@@ -210,8 +248,10 @@ sdk.Ndebit(budgetRequest).then(response => {
 
 ```ts
 new ClinkSDK(settings: ClinkSettings, pool?: AbstractSimplePool)
+ClinkSDK.fromNprofile(nprofile: string, privateKey: Uint8Array, opts?: { defaultTimeoutSeconds?: number, pool?: AbstractSimplePool })
 ```
 - `settings`: `{ privateKey: Uint8Array, relays: string[], toPubKey: string, defaultTimeoutSeconds?: number }`
+- `fromNprofile`: decodes service pubkey + relays from an `nprofile`.
 - `pool`: Optional custom Nostr pool (defaults to `SimplePool` from this package’s pinned `nostr-tools`). If you pass one, build it with `SimplePool` imported from `@shocknet/clink-sdk`.
 
 #### Methods
@@ -225,6 +265,10 @@ new ClinkSDK(settings: ClinkSettings, pool?: AbstractSimplePool)
 - `Nmanage(data: NmanageRequest, timeoutSeconds?: number)`
   - Sends a `kind: 21003` management request.
   - Returns a `Promise<NmanageResponse>` that resolves with the result of the management action.
+- `Nbeacon(timeoutSeconds?: number)`
+  - Fetches the latest kind `30078` `d=clink-node` beacon (liveness, display, fees, advertised kinds).
+- `Nenroll(opts?: { difficulty?: number }, timeoutSeconds?: number)`
+  - Sends a kind `21004` Enroll request (`{}`). Mines NIP-13 when `difficulty > 0`. If `difficulty` is omitted, uses a fresh beacon’s `enroll_difficulty` when present, otherwise probes and remine once on GFY `5`.
 - `Stop()`
   - Closes relay connections on the internal pool. Call when finished so the process can exit cleanly.
 
@@ -274,6 +318,8 @@ Pinned by this package — import these from `@shocknet/clink-sdk`, not from a s
 - **`OfferPriceType`**: `enum { Fixed = 0, Variable = 1, Spontaneous = 2 }`
 - **`BudgetFrequency`**: `{ number: number, unit: 'day' | 'week' | 'month' }`
 - **`ClinkSettings`**: `{ privateKey: Uint8Array, relays: string[], toPubKey: string, defaultTimeoutSeconds?: number }`
+- **`NenrollResponse`**: `{ res: 'ok', noffer: string, ndebit: string, nmanage: string } | { res: 'GFY', code: number, error: string, required_difficulty?: number }`
+- **`ClinkBeacon`**: `{ pubkey: string, created_at: number, operator?: string, content: ClinkBeaconContent }`
 - **`AbstractSimplePool`**, **`UnsignedEvent`**: see Nostr helpers above
 
 ---

--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ const invoice = await sdk.Noffer({ offer: noffer.data.offer, amount_sats: 21 });
 sdk.Stop();
 ```
 
-`Nenroll()` with no args uses a fresh beacon's `enroll_difficulty` when present, otherwise probes and remine once on GFY `5`. Pass `{ difficulty: 0 }` to probe, or `{ difficulty: 18 }` to skip the lookup.
+`Nenroll()` with no args uses a fresh beacon's `enroll_difficulty` when present, otherwise probes and remine once on GFY `5`. Pass `{ difficulty: 0 }` to probe, or `{ difficulty: 18 }` to skip the lookup. Mining is capped at `MAX_ENROLL_POW_BITS` (24). A beacon or GFY asking for more is ignored (probe / return the GFY); an explicit `{ difficulty }` above the cap throws.
 
 ---
 
@@ -268,7 +268,7 @@ ClinkSDK.fromNprofile(nprofile: string, privateKey: Uint8Array, opts?: { default
 - `Nbeacon(timeoutSeconds?: number)`
   - Fetches the latest kind `30078` `d=clink-node` beacon (liveness, display, fees, advertised kinds).
 - `Nenroll(opts?: { difficulty?: number }, timeoutSeconds?: number)`
-  - Sends a kind `21004` Enroll request (`{}`). Mines NIP-13 when `difficulty > 0`. If `difficulty` is omitted, uses a fresh beacon’s `enroll_difficulty` when present, otherwise probes and remine once on GFY `5`.
+  - Sends a kind `21004` Enroll request (`{}`). Mines NIP-13 when `difficulty > 0`, up to `MAX_ENROLL_POW_BITS` (24). If `difficulty` is omitted, uses a fresh beacon’s `enroll_difficulty` when present and in range, otherwise probes and remine once on GFY `5`.
 - `Stop()`
   - Closes relay connections on the internal pool. Call when finished so the process can exit cleanly.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@shocknet/clink-sdk",
-    "version": "1.6.1",
+    "version": "1.7.0",
     "description": "sdk client for clink",
     "repository": {
         "type": "git",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -7,3 +7,5 @@ export const CLINK_BEACON_KIND = 30078
 export const CLINK_BEACON_D_TAG = "clink-node"
 export const BEACON_STALE_AFTER_SECONDS = 180
 export const BEACON_FUTURE_SKEW_SECONDS = 30
+/** Client will not mine more than this many NIP-13 bits (spec recommended: 18). */
+export const MAX_ENROLL_POW_BITS = 24

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,9 @@
+export const CLINK_VERSION = "1"
+export const CLINK_OFFER_KIND = 21001
+export const CLINK_DEBIT_KIND = 21002
+export const CLINK_MANAGE_KIND = 21003
+export const CLINK_ENROLL_KIND = 21004
+export const CLINK_BEACON_KIND = 30078
+export const CLINK_BEACON_D_TAG = "clink-node"
+export const BEACON_STALE_AFTER_SECONDS = 180
+export const BEACON_FUTURE_SKEW_SECONDS = 30

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,8 @@ import { SimplePool, getPublicKey, nip19, generateSecretKey, finalizeEvent, nip4
 import { SendNofferRequest, NofferData, NofferReceipt } from "./noffer.js"
 import { NdebitData, SendNdebitRequest, generateK1, validateK1, newNdebitBudgetRequest, newNdebitPaymentRequest } from "./ndebit.js"
 import { NmanageRequest, SendNmanageRequest, newListRequest } from "./nmanage.js"
+import { SendNenrollRequest, NenrollOptions } from "./nenroll.js"
+import { FetchClinkBeacon, enrollDifficultyFromBeacon } from "./nbeacon.js"
 import { decodeBech32 } from "./nip19Extension.js"
 import { setDebug } from "./sender.js"
 
@@ -11,6 +13,23 @@ export type ClinkSettings = {
     relays: string[]
     toPubKey: string
     defaultTimeoutSeconds?: number
+}
+
+const nprofileSettings = (nprofile: string, privateKey: Uint8Array, extra?: Pick<ClinkSettings, "defaultTimeoutSeconds">): ClinkSettings => {
+    const decoded = nip19.decode(nprofile)
+    if (decoded.type !== "nprofile") {
+        throw new Error("expected nprofile")
+    }
+    const relays = decoded.data.relays || []
+    if (relays.length === 0) {
+        throw new Error("nprofile has no relays")
+    }
+    return {
+        privateKey,
+        relays,
+        toPubKey: decoded.data.pubkey,
+        defaultTimeoutSeconds: extra?.defaultTimeoutSeconds,
+    }
 }
 
 export class ClinkSDK {
@@ -25,6 +44,10 @@ export class ClinkSDK {
         }
     }
 
+    static fromNprofile(nprofile: string, privateKey: Uint8Array, opts?: { defaultTimeoutSeconds?: number, pool?: AbstractSimplePool }) {
+        return new ClinkSDK(nprofileSettings(nprofile, privateKey, opts), opts?.pool)
+    }
+
     Noffer = (data: NofferData, onReceipt?: (receipt: NofferReceipt) => void, timeoutSeconds?: number) => {
         return SendNofferRequest(this.pool, this.settings.privateKey, this.settings.relays, this.settings.toPubKey, data, timeoutSeconds || this.settings.defaultTimeoutSeconds, onReceipt)
     }
@@ -37,9 +60,28 @@ export class ClinkSDK {
         return SendNmanageRequest(this.pool, this.settings.privateKey, this.settings.relays, this.settings.toPubKey, data, timeoutSeconds || this.settings.defaultTimeoutSeconds)
     }
 
+    Nbeacon = (timeoutSeconds?: number) => {
+        return FetchClinkBeacon(this.pool, this.settings.relays, this.settings.toPubKey, timeoutSeconds || 10)
+    }
+
+    Nenroll = async (opts?: NenrollOptions, timeoutSeconds?: number) => {
+        const timeout = timeoutSeconds || this.settings.defaultTimeoutSeconds
+        const difficulty = opts?.difficulty ?? await this.beaconEnrollDifficulty()
+        return SendNenrollRequest(this.pool, this.settings.privateKey, this.settings.relays, this.settings.toPubKey, difficulty, timeout)
+    }
+
     /** Close relay connections. Call when done so the process can exit. */
     Stop = () => {
         this.pool.destroy()
+    }
+
+    private beaconEnrollDifficulty = async (): Promise<number> => {
+        try {
+            const beacon = await this.Nbeacon()
+            return enrollDifficultyFromBeacon(beacon) ?? 0
+        } catch {
+            return 0
+        }
     }
 
     static decodeBech32 = decodeBech32
@@ -55,6 +97,10 @@ export * from './nip19Extension.js'
 export * from './noffer.js'
 export * from './nmanage.js'
 export * from "./ndebit.js"
+export * from "./nenroll.js"
+export * from "./nbeacon.js"
+export * from "./nip13.js"
+export * from "./constants.js"
 export { setDebug }
 /** Re-exported from the SDK's pinned nostr-tools — import these here, do not install nostr-tools yourself. */
 export { SimplePool, getPublicKey, nip19, generateSecretKey, finalizeEvent, nip44, verifyEvent }

--- a/src/nbeacon.ts
+++ b/src/nbeacon.ts
@@ -7,6 +7,7 @@ import {
     CLINK_BEACON_KIND,
     CLINK_VERSION,
 } from "./constants.js"
+import { enrollPowBitsOk } from "./nip13.js"
 
 export type ClinkBeaconFees = { serviceFeeFloor: number, serviceFeeBps: number }
 
@@ -139,7 +140,11 @@ export const enrollDifficultyFromBeacon = (beacon: ClinkBeacon | null, nowMs = D
     if (!beacon || !beaconIsFresh(beacon, nowMs)) {
         return undefined
     }
-    return beacon.content.enroll_difficulty
+    const bits = beacon.content.enroll_difficulty
+    if (bits === undefined || bits === 0 || !enrollPowBitsOk(bits)) {
+        return undefined
+    }
+    return bits
 }
 
 export const FetchClinkBeacon = async (

--- a/src/nbeacon.ts
+++ b/src/nbeacon.ts
@@ -1,5 +1,5 @@
 import { AbstractSimplePool } from "nostr-tools/lib/types/pool"
-import { Event } from "nostr-tools"
+import { Event, verifyEvent } from "nostr-tools"
 import {
     BEACON_FUTURE_SKEW_SECONDS,
     BEACON_STALE_AFTER_SECONDS,
@@ -96,7 +96,10 @@ const dTag = (tags: string[][]): string | undefined => tags.find(t => t[0] === "
 const versionTag = (tags: string[][]): string | undefined => tags.find(t => t[0] === "clink_version")?.[1]
 const operatorTag = (tags: string[][]): string | undefined => tags.find(t => t[0] === "operator")?.[1]
 
-export const parseClinkBeaconEvent = (event: Pick<Event, "pubkey" | "created_at" | "kind" | "tags" | "content">): ClinkBeacon | null => {
+export const parseClinkBeaconEvent = (event: Event): ClinkBeacon | null => {
+    if (!verifyEvent(event)) {
+        return null
+    }
     if (event.kind !== CLINK_BEACON_KIND) {
         return null
     }
@@ -167,6 +170,9 @@ export const FetchClinkBeacon = async (
         }], {
             onevent: (event: Event) => {
                 if (event.pubkey.toLowerCase() !== expectedPub) {
+                    return
+                }
+                if (!verifyEvent(event)) {
                     return
                 }
                 if (!best || event.created_at > best.created_at) {

--- a/src/nbeacon.ts
+++ b/src/nbeacon.ts
@@ -1,0 +1,179 @@
+import { AbstractSimplePool } from "nostr-tools/lib/types/pool"
+import { Event } from "nostr-tools"
+import {
+    BEACON_FUTURE_SKEW_SECONDS,
+    BEACON_STALE_AFTER_SECONDS,
+    CLINK_BEACON_D_TAG,
+    CLINK_BEACON_KIND,
+    CLINK_VERSION,
+} from "./constants.js"
+
+export type ClinkBeaconFees = { serviceFeeFloor: number, serviceFeeBps: number }
+
+export type ClinkBeaconContent = {
+    name?: string
+    avatarUrl?: string
+    website?: string
+    description?: string
+    relays?: string[]
+    fees?: ClinkBeaconFees
+    enroll_difficulty?: number
+    supported_kinds?: number[]
+}
+
+export type ClinkBeacon = {
+    pubkey: string
+    created_at: number
+    operator?: string
+    content: ClinkBeaconContent
+}
+
+const asFiniteNumber = (value: unknown): number | undefined => {
+    if (typeof value !== "number" || !Number.isFinite(value)) {
+        return undefined
+    }
+    return value
+}
+
+const asString = (value: unknown): string | undefined => {
+    return typeof value === "string" && value.length > 0 ? value : undefined
+}
+
+const asStringList = (value: unknown): string[] | undefined => {
+    if (!Array.isArray(value) || value.some(item => typeof item !== "string")) {
+        return undefined
+    }
+    return value
+}
+
+const asNumberList = (value: unknown): number[] | undefined => {
+    if (!Array.isArray(value) || value.some(item => typeof item !== "number" || !Number.isFinite(item))) {
+        return undefined
+    }
+    return value
+}
+
+const parseFees = (value: unknown): ClinkBeaconFees | undefined => {
+    if (typeof value !== "object" || value === null) {
+        return undefined
+    }
+    const serviceFeeFloor = asFiniteNumber((value as { serviceFeeFloor?: unknown }).serviceFeeFloor)
+    const serviceFeeBps = asFiniteNumber((value as { serviceFeeBps?: unknown }).serviceFeeBps)
+    if (serviceFeeFloor === undefined || serviceFeeBps === undefined) {
+        return undefined
+    }
+    return { serviceFeeFloor, serviceFeeBps }
+}
+
+export const parseClinkBeaconContent = (raw: unknown): ClinkBeaconContent => {
+    if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+        return {}
+    }
+    const src = raw as Record<string, unknown>
+    const content: ClinkBeaconContent = {}
+    const name = asString(src.name)
+    const avatarUrl = asString(src.avatarUrl)
+    const website = asString(src.website)
+    const description = asString(src.description)
+    const relays = asStringList(src.relays)
+    const fees = parseFees(src.fees)
+    const enrollDifficulty = asFiniteNumber(src.enroll_difficulty)
+    const supportedKinds = asNumberList(src.supported_kinds)
+    if (name) content.name = name
+    if (avatarUrl) content.avatarUrl = avatarUrl
+    if (website) content.website = website
+    if (description) content.description = description
+    if (relays) content.relays = relays
+    if (fees) content.fees = fees
+    if (enrollDifficulty !== undefined && Number.isInteger(enrollDifficulty) && enrollDifficulty >= 0) {
+        content.enroll_difficulty = enrollDifficulty
+    }
+    if (supportedKinds) content.supported_kinds = supportedKinds
+    return content
+}
+
+const dTag = (tags: string[][]): string | undefined => tags.find(t => t[0] === "d")?.[1]
+const versionTag = (tags: string[][]): string | undefined => tags.find(t => t[0] === "clink_version")?.[1]
+const operatorTag = (tags: string[][]): string | undefined => tags.find(t => t[0] === "operator")?.[1]
+
+export const parseClinkBeaconEvent = (event: Pick<Event, "pubkey" | "created_at" | "kind" | "tags" | "content">): ClinkBeacon | null => {
+    if (event.kind !== CLINK_BEACON_KIND) {
+        return null
+    }
+    if (dTag(event.tags) !== CLINK_BEACON_D_TAG) {
+        return null
+    }
+    if (versionTag(event.tags) !== CLINK_VERSION) {
+        return null
+    }
+    let parsed: unknown
+    try {
+        parsed = JSON.parse(event.content)
+    } catch {
+        return null
+    }
+    const operator = operatorTag(event.tags)
+    return {
+        pubkey: event.pubkey.toLowerCase(),
+        created_at: event.created_at,
+        operator: operator ? operator.toLowerCase() : undefined,
+        content: parseClinkBeaconContent(parsed),
+    }
+}
+
+export const beaconIsFresh = (beacon: ClinkBeacon, nowMs = Date.now()): boolean => {
+    const ageSeconds = nowMs / 1000 - beacon.created_at
+    if (ageSeconds > BEACON_STALE_AFTER_SECONDS) {
+        return false
+    }
+    if (ageSeconds < -BEACON_FUTURE_SKEW_SECONDS) {
+        return false
+    }
+    return true
+}
+
+export const enrollDifficultyFromBeacon = (beacon: ClinkBeacon | null, nowMs = Date.now()): number | undefined => {
+    if (!beacon || !beaconIsFresh(beacon, nowMs)) {
+        return undefined
+    }
+    return beacon.content.enroll_difficulty
+}
+
+export const FetchClinkBeacon = async (
+    pool: AbstractSimplePool,
+    relays: string[],
+    servicePub: string,
+    timeoutSeconds = 10,
+): Promise<ClinkBeacon | null> => {
+    const expectedPub = servicePub.toLowerCase()
+    return new Promise(resolve => {
+        let settled = false
+        let best: Event | null = null
+        let closer = { close: () => { } }
+        const finish = () => {
+            if (settled) {
+                return
+            }
+            settled = true
+            clearTimeout(timer)
+            closer.close()
+            resolve(best ? parseClinkBeaconEvent(best) : null)
+        }
+        const timer = setTimeout(finish, timeoutSeconds * 1000)
+        closer = pool.subscribeMany(relays, [{
+            kinds: [CLINK_BEACON_KIND],
+            authors: [expectedPub],
+            "#d": [CLINK_BEACON_D_TAG],
+        }], {
+            onevent: (event: Event) => {
+                if (event.pubkey.toLowerCase() !== expectedPub) {
+                    return
+                }
+                if (!best || event.created_at > best.created_at) {
+                    best = event
+                }
+            },
+            oneose: finish,
+        })
+    })
+}

--- a/src/nenroll.ts
+++ b/src/nenroll.ts
@@ -2,7 +2,7 @@ import { nip44, getPublicKey, type UnsignedEvent } from "nostr-tools"
 import { AbstractSimplePool } from "nostr-tools/lib/types/pool"
 import { sendRequest } from "./sender.js"
 import { CLINK_ENROLL_KIND, CLINK_VERSION } from "./constants.js"
-import { mineNip13 } from "./nip13.js"
+import { enrollPowBitsOk, mineNip13 } from "./nip13.js"
 
 const { getConversationKey, encrypt } = nip44
 
@@ -60,12 +60,15 @@ export const SendNenrollRequest = async (
     timeoutSeconds?: number,
 ): Promise<NenrollResponse> => {
     const used = difficulty > 0 ? difficulty : 0
+    if (used > 0 && !enrollPowBitsOk(used)) {
+        throw new Error(`enroll PoW difficulty ${used} exceeds max`)
+    }
     const first = await sendEnrollOnce(pool, privateKey, relays, toPubKey, used, timeoutSeconds)
     if (!isGfy5(first)) {
         return first
     }
     const required = first.required_difficulty
-    if (typeof required !== "number" || !Number.isInteger(required) || required <= used) {
+    if (typeof required !== "number" || !enrollPowBitsOk(required) || required <= used) {
         return first
     }
     return sendEnrollOnce(pool, privateKey, relays, toPubKey, required, timeoutSeconds)

--- a/src/nenroll.ts
+++ b/src/nenroll.ts
@@ -1,0 +1,72 @@
+import { nip44, getPublicKey, type UnsignedEvent } from "nostr-tools"
+import { AbstractSimplePool } from "nostr-tools/lib/types/pool"
+import { sendRequest } from "./sender.js"
+import { CLINK_ENROLL_KIND, CLINK_VERSION } from "./constants.js"
+import { mineNip13 } from "./nip13.js"
+
+const { getConversationKey, encrypt } = nip44
+
+export type NenrollSuccess = { res: "ok", noffer: string, ndebit: string, nmanage: string }
+export type NenrollFailure = {
+    res: "GFY"
+    code: number
+    error: string
+    required_difficulty?: number
+    retry_after?: number
+    delta?: { max_delta_ms: number, actual_delta_ms: number }
+}
+export type NenrollResponse = NenrollSuccess | NenrollFailure
+
+export type NenrollOptions = {
+    /** NIP-13 bits to mine before send. `0` probes. Omit to let the caller pick (beacon or probe). */
+    difficulty?: number
+}
+
+const isGfy5 = (res: NenrollResponse): res is NenrollFailure => {
+    return res.res === "GFY" && res.code === 5
+}
+
+export const newNenrollEvent = (content: string, fromPub: string, toPub: string): UnsignedEvent => ({
+    content,
+    created_at: Math.floor(Date.now() / 1000),
+    kind: CLINK_ENROLL_KIND,
+    pubkey: fromPub,
+    tags: [["p", toPub], ["clink_version", CLINK_VERSION]],
+})
+
+const sendEnrollOnce = (
+    pool: AbstractSimplePool,
+    privateKey: Uint8Array,
+    relays: string[],
+    toPubKey: string,
+    bits: number,
+    timeoutSeconds?: number,
+): Promise<NenrollResponse> => {
+    const publicKey = getPublicKey(privateKey)
+    const content = encrypt(JSON.stringify({}), getConversationKey(privateKey, toPubKey))
+    let event = newNenrollEvent(content, publicKey, toPubKey)
+    if (bits > 0) {
+        event = mineNip13(event, bits)
+    }
+    return sendRequest(pool, { privateKey, publicKey }, relays, toPubKey, event, CLINK_ENROLL_KIND, timeoutSeconds)
+}
+
+export const SendNenrollRequest = async (
+    pool: AbstractSimplePool,
+    privateKey: Uint8Array,
+    relays: string[],
+    toPubKey: string,
+    difficulty = 0,
+    timeoutSeconds?: number,
+): Promise<NenrollResponse> => {
+    const used = difficulty > 0 ? difficulty : 0
+    const first = await sendEnrollOnce(pool, privateKey, relays, toPubKey, used, timeoutSeconds)
+    if (!isGfy5(first)) {
+        return first
+    }
+    const required = first.required_difficulty
+    if (typeof required !== "number" || !Number.isInteger(required) || required <= used) {
+        return first
+    }
+    return sendEnrollOnce(pool, privateKey, relays, toPubKey, required, timeoutSeconds)
+}

--- a/src/nip13.ts
+++ b/src/nip13.ts
@@ -1,10 +1,18 @@
 import { nip13, type UnsignedEvent } from "nostr-tools"
+import { MAX_ENROLL_POW_BITS } from "./constants.js"
 
 export const countLeadingZeroBits = nip13.getPow
+
+export const enrollPowBitsOk = (bits: number): boolean => {
+    return Number.isInteger(bits) && bits >= 0 && bits <= MAX_ENROLL_POW_BITS
+}
 
 export const mineNip13 = (event: UnsignedEvent, bits: number): UnsignedEvent => {
     if (bits <= 0) {
         return event
+    }
+    if (!enrollPowBitsOk(bits)) {
+        throw new Error(`enroll PoW difficulty ${bits} exceeds max ${MAX_ENROLL_POW_BITS}`)
     }
     const unsigned: UnsignedEvent = {
         ...event,

--- a/src/nip13.ts
+++ b/src/nip13.ts
@@ -1,0 +1,21 @@
+import { nip13, type UnsignedEvent } from "nostr-tools"
+
+export const countLeadingZeroBits = nip13.getPow
+
+export const mineNip13 = (event: UnsignedEvent, bits: number): UnsignedEvent => {
+    if (bits <= 0) {
+        return event
+    }
+    const unsigned: UnsignedEvent = {
+        ...event,
+        tags: event.tags.filter(t => t[0] !== "nonce"),
+    }
+    const mined = nip13.minePow(unsigned, bits)
+    return {
+        content: mined.content,
+        created_at: mined.created_at,
+        kind: mined.kind,
+        pubkey: mined.pubkey,
+        tags: mined.tags,
+    }
+}

--- a/src/sender.ts
+++ b/src/sender.ts
@@ -1,5 +1,6 @@
-import { nip44, finalizeEvent, UnsignedEvent } from "nostr-tools"
+import { nip44, finalizeEvent, verifyEvent, UnsignedEvent, type Event } from "nostr-tools"
 import { AbstractSimplePool, SubCloser } from "nostr-tools/lib/types/pool"
+import { CLINK_VERSION } from "./constants.js"
 const { getConversationKey, decrypt } = nip44
 
 let debug = false
@@ -17,11 +18,50 @@ const logError = (...args: unknown[]) => {
     if (debug) console.error(...args)
 }
 
+const firstTag = (tags: string[][], name: string): string | undefined =>
+    tags.find(t => t[0] === name)?.[1]
+
+const hexEq = (a: string, b: string): boolean =>
+    a.toLowerCase() === b.toLowerCase()
+
+type ResponseExpect = {
+    pubkey: string
+    kind: number
+    requestorPub: string
+    requestId: string
+}
+
+/** Accept only a signed CLINK reply from the expected peer, tagged to this request. */
+export const isClinkResponse = (event: Event, expect: ResponseExpect): boolean => {
+    if (event.kind !== expect.kind) {
+        return false
+    }
+    if (!hexEq(event.pubkey, expect.pubkey)) {
+        return false
+    }
+    if (!verifyEvent(event)) {
+        return false
+    }
+    if (firstTag(event.tags, "clink_version") !== CLINK_VERSION) {
+        return false
+    }
+    if (!hexEq(firstTag(event.tags, "p") ?? "", expect.requestorPub)) {
+        return false
+    }
+    return (firstTag(event.tags, "e") ?? "") === expect.requestId
+}
+
 type Pair = { privateKey: Uint8Array, publicKey: string }
 export const sendRequest = async <T>(pool: AbstractSimplePool, pair: Pair, relays: string[], toPub: string, e: UnsignedEvent, kindExpected: number, timeoutSeconds?: number, moreCb?: (data: any) => void): Promise<T> => {
     const signed = finalizeEvent(e, pair.privateKey)
     // Wire events use lowercase hex; callers sometimes pass mixed case.
     const expectedPub = toPub.toLowerCase()
+    const expect: ResponseExpect = {
+        pubkey: expectedPub,
+        kind: kindExpected,
+        requestorPub: pair.publicKey,
+        requestId: signed.id,
+    }
     log(`[ClinkSDK] Sending request: kind=${kindExpected}, eventId=${signed.id}, toPub=${expectedPub}, relays=${relays.join(',')}, timeout=${timeoutSeconds}s`)
 
     return new Promise<T>((res, rej) => {
@@ -57,16 +97,14 @@ export const sendRequest = async <T>(pool: AbstractSimplePool, pair: Pair, relay
         try {
             // Subscribe BEFORE publish — otherwise a fast reply can arrive with no listener
             closer = pool.subscribeMany(relays, [filter], {
-                onevent: async (e) => {
-                    log(`[ClinkSDK] Received response event: kind=${e.kind}, eventId=${e.id}, from=${e.pubkey}`)
-                    // Filter is tag-based only — ignore anyone who is not the expected peer so a
-                    // forged #e/#p event cannot DoS the request by failing decrypt ahead of the real reply.
-                    if (e.pubkey !== expectedPub) {
-                        log(`[ClinkSDK] Ignoring event from unexpected pubkey ${e.pubkey} (expected ${expectedPub})`)
+                onevent: async (event) => {
+                    log(`[ClinkSDK] Received response event: kind=${event.kind}, eventId=${event.id}, from=${event.pubkey}`)
+                    if (!isClinkResponse(event, expect)) {
+                        log(`[ClinkSDK] Ignoring event that is not a valid CLINK response for eventId=${signed.id}`)
                         return
                     }
                     try {
-                        const content = decrypt(e.content, getConversationKey(pair.privateKey, expectedPub))
+                        const content = decrypt(event.content, getConversationKey(pair.privateKey, expectedPub))
                         const parsed = JSON.parse(content)
                         if (!settled) {
                             settled = true

--- a/test/unit/enroll-beacon.test.mjs
+++ b/test/unit/enroll-beacon.test.mjs
@@ -4,6 +4,7 @@ import { generateSecretKey, getPublicKey, finalizeEvent, nip19, nip44 } from 'no
 import {
   countLeadingZeroBits,
   mineNip13,
+  FetchClinkBeacon,
   parseClinkBeaconContent,
   parseClinkBeaconEvent,
   beaconIsFresh,
@@ -46,6 +47,16 @@ describe('nip13 mining', () => {
 
 describe('beacon parse', () => {
   const now = Math.floor(Date.now() / 1000)
+  const servicePriv = generateSecretKey()
+  const servicePub = getPublicKey(servicePriv)
+
+  const signBeacon = (overrides = {}) => finalizeEvent({
+    kind: CLINK_BEACON_KIND,
+    created_at: now,
+    tags: [['d', CLINK_BEACON_D_TAG], ['clink_version', CLINK_VERSION]],
+    content: '{}',
+    ...overrides,
+  }, servicePriv)
 
   it('parses clink-node content and ignores junk', () => {
     const content = parseClinkBeaconContent({
@@ -61,38 +72,70 @@ describe('beacon parse', () => {
     assert.deepEqual(content.fees, { serviceFeeFloor: 1, serviceFeeBps: 60 })
   })
 
+  it('rejects unsigned and forged events', () => {
+    const unsigned = {
+      kind: CLINK_BEACON_KIND,
+      pubkey: servicePub,
+      created_at: now,
+      tags: [['d', CLINK_BEACON_D_TAG], ['clink_version', CLINK_VERSION]],
+      content: JSON.stringify({ enroll_difficulty: 1 }),
+      id: '00'.repeat(32),
+      sig: '00'.repeat(64),
+    }
+    assert.equal(parseClinkBeaconEvent(unsigned), null)
+  })
+
   it('rejects legacy d-tag and missing version', () => {
-    assert.equal(parseClinkBeaconEvent({
-      kind: CLINK_BEACON_KIND,
-      pubkey: 'ab'.repeat(32),
-      created_at: now,
-      tags: [['d', 'Lightning.Pub']],
-      content: '{}',
-    }), null)
-    assert.equal(parseClinkBeaconEvent({
-      kind: CLINK_BEACON_KIND,
-      pubkey: 'ab'.repeat(32),
-      created_at: now,
+    assert.equal(parseClinkBeaconEvent(signBeacon({
+      tags: [['d', 'Lightning.Pub'], ['clink_version', CLINK_VERSION]],
+    })), null)
+    assert.equal(parseClinkBeaconEvent(signBeacon({
       tags: [['d', CLINK_BEACON_D_TAG]],
-      content: '{}',
-    }), null)
+    })), null)
   })
 
   it('uses enroll_difficulty only while the beacon is fresh', () => {
-    const beacon = parseClinkBeaconEvent({
-      kind: CLINK_BEACON_KIND,
-      pubkey: 'AB'.repeat(32),
-      created_at: now,
+    const beacon = parseClinkBeaconEvent(signBeacon({
       tags: [['d', CLINK_BEACON_D_TAG], ['clink_version', CLINK_VERSION], ['operator', 'CD'.repeat(32)]],
       content: JSON.stringify({ enroll_difficulty: 18 }),
-    })
+    }))
     assert.ok(beacon)
-    assert.equal(beacon.pubkey, 'ab'.repeat(32))
+    assert.equal(beacon.pubkey, servicePub)
     assert.equal(beacon.operator, 'cd'.repeat(32))
     assert.equal(beaconIsFresh(beacon, now * 1000), true)
     assert.equal(enrollDifficultyFromBeacon(beacon, now * 1000), 18)
     assert.equal(enrollDifficultyFromBeacon(beacon, (now + 181) * 1000), undefined)
     assert.equal(beaconIsFresh(beacon, (now - 31) * 1000), false)
+  })
+
+  it('ignores unsigned relay spoofs when fetching', async () => {
+    const signed = signBeacon({
+      created_at: now,
+      content: JSON.stringify({ enroll_difficulty: 18, name: 'real' }),
+    })
+    const spoof = {
+      kind: signed.kind,
+      pubkey: signed.pubkey,
+      created_at: now + 10,
+      tags: signed.tags,
+      content: JSON.stringify({ enroll_difficulty: 1, name: 'fake' }),
+      id: '11'.repeat(32),
+      sig: '11'.repeat(64),
+    }
+    const pool = {
+      subscribeMany(_relays, _filters, opts) {
+        queueMicrotask(() => {
+          opts.onevent(spoof)
+          opts.onevent(signed)
+          opts.oneose()
+        })
+        return { close: () => {} }
+      },
+    }
+    const beacon = await FetchClinkBeacon(pool, ['wss://relay.example'], servicePub, 2)
+    assert.ok(beacon)
+    assert.equal(beacon.content.name, 'real')
+    assert.equal(beacon.content.enroll_difficulty, 18)
   })
 })
 

--- a/test/unit/enroll-beacon.test.mjs
+++ b/test/unit/enroll-beacon.test.mjs
@@ -1,6 +1,7 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
-import { generateSecretKey, getPublicKey, finalizeEvent, nip19, nip44 } from 'nostr-tools'
+import { generateSecretKey, getPublicKey, finalizeEvent, nip19 } from 'nostr-tools'
+import { signedClinkReply } from './signed-reply.mjs'
 import {
   countLeadingZeroBits,
   mineNip13,
@@ -18,8 +19,6 @@ import {
   ClinkSDK,
   MAX_ENROLL_POW_BITS,
 } from '../../build/index.js'
-
-const { getConversationKey, encrypt } = nip44
 
 describe('nip13 mining', () => {
   it('counts leading zero bits', () => {
@@ -197,12 +196,7 @@ describe('enroll remine', () => {
         const payload = gfy
           ? { res: 'GFY', code: 5, error: 'Insufficient proof of work', required_difficulty: 8 }
           : { res: 'ok', noffer: 'noffer1x', ndebit: 'ndebit1x', nmanage: 'nmanage1x' }
-        const reply = {
-          id: `reply-${published.length}`,
-          kind: CLINK_ENROLL_KIND,
-          pubkey: serverPub,
-          content: encrypt(JSON.stringify(payload), getConversationKey(serverPriv, clientPub)),
-        }
+        const reply = signedClinkReply(serverPriv, clientPub, event.id, payload, CLINK_ENROLL_KIND)
         queueMicrotask(() => onevent(reply))
         return [Promise.resolve('ok')]
       },
@@ -230,17 +224,12 @@ describe('enroll remine', () => {
       },
       publish(_relays, event) {
         published.push(event)
-        const reply = {
-          id: `reply-${published.length}`,
-          kind: CLINK_ENROLL_KIND,
-          pubkey: serverPub,
-          content: encrypt(JSON.stringify({
-            res: 'GFY',
-            code: 5,
-            error: 'Insufficient proof of work',
-            required_difficulty: 64,
-          }), getConversationKey(serverPriv, clientPub)),
-        }
+        const reply = signedClinkReply(serverPriv, clientPub, event.id, {
+          res: 'GFY',
+          code: 5,
+          error: 'Insufficient proof of work',
+          required_difficulty: 64,
+        }, CLINK_ENROLL_KIND)
         queueMicrotask(() => onevent(reply))
         return [Promise.resolve('ok')]
       },

--- a/test/unit/enroll-beacon.test.mjs
+++ b/test/unit/enroll-beacon.test.mjs
@@ -1,0 +1,159 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { generateSecretKey, getPublicKey, finalizeEvent, nip19, nip44 } from 'nostr-tools'
+import {
+  countLeadingZeroBits,
+  mineNip13,
+  parseClinkBeaconContent,
+  parseClinkBeaconEvent,
+  beaconIsFresh,
+  enrollDifficultyFromBeacon,
+  newNenrollEvent,
+  SendNenrollRequest,
+  CLINK_ENROLL_KIND,
+  CLINK_BEACON_KIND,
+  CLINK_BEACON_D_TAG,
+  CLINK_VERSION,
+  ClinkSDK,
+} from '../../build/index.js'
+
+const { getConversationKey, encrypt } = nip44
+
+describe('nip13 mining', () => {
+  it('counts leading zero bits', () => {
+    assert.equal(countLeadingZeroBits('0'.repeat(64)), 256)
+    assert.equal(countLeadingZeroBits('f'.repeat(64)), 0)
+    assert.equal(countLeadingZeroBits('1' + 'f'.repeat(63)), 3)
+  })
+
+  it('mines an enroll event to the committed target', () => {
+    const priv = generateSecretKey()
+    const event = newNenrollEvent('{}', getPublicKey(priv), 'cd'.repeat(32))
+    const mined = mineNip13(event, 8)
+    const nonce = mined.tags.find(t => t[0] === 'nonce')
+    assert.ok(nonce)
+    assert.equal(nonce[2], '8')
+    const signed = finalizeEvent(mined, priv)
+    assert.ok(countLeadingZeroBits(signed.id) >= 8)
+  })
+
+  it('leaves the event alone when bits are 0', () => {
+    const event = newNenrollEvent('{}', 'ab'.repeat(32), 'cd'.repeat(32))
+    assert.equal(mineNip13(event, 0), event)
+    assert.equal(event.tags.some(t => t[0] === 'nonce'), false)
+  })
+})
+
+describe('beacon parse', () => {
+  const now = Math.floor(Date.now() / 1000)
+
+  it('parses clink-node content and ignores junk', () => {
+    const content = parseClinkBeaconContent({
+      name: 'test pub',
+      enroll_difficulty: 18,
+      supported_kinds: [21001, 21004],
+      fees: { serviceFeeFloor: 1, serviceFeeBps: 60 },
+      extra: 'nope',
+    })
+    assert.equal(content.name, 'test pub')
+    assert.equal(content.enroll_difficulty, 18)
+    assert.deepEqual(content.supported_kinds, [21001, 21004])
+    assert.deepEqual(content.fees, { serviceFeeFloor: 1, serviceFeeBps: 60 })
+  })
+
+  it('rejects legacy d-tag and missing version', () => {
+    assert.equal(parseClinkBeaconEvent({
+      kind: CLINK_BEACON_KIND,
+      pubkey: 'ab'.repeat(32),
+      created_at: now,
+      tags: [['d', 'Lightning.Pub']],
+      content: '{}',
+    }), null)
+    assert.equal(parseClinkBeaconEvent({
+      kind: CLINK_BEACON_KIND,
+      pubkey: 'ab'.repeat(32),
+      created_at: now,
+      tags: [['d', CLINK_BEACON_D_TAG]],
+      content: '{}',
+    }), null)
+  })
+
+  it('uses enroll_difficulty only while the beacon is fresh', () => {
+    const beacon = parseClinkBeaconEvent({
+      kind: CLINK_BEACON_KIND,
+      pubkey: 'AB'.repeat(32),
+      created_at: now,
+      tags: [['d', CLINK_BEACON_D_TAG], ['clink_version', CLINK_VERSION], ['operator', 'CD'.repeat(32)]],
+      content: JSON.stringify({ enroll_difficulty: 18 }),
+    })
+    assert.ok(beacon)
+    assert.equal(beacon.pubkey, 'ab'.repeat(32))
+    assert.equal(beacon.operator, 'cd'.repeat(32))
+    assert.equal(beaconIsFresh(beacon, now * 1000), true)
+    assert.equal(enrollDifficultyFromBeacon(beacon, now * 1000), 18)
+    assert.equal(enrollDifficultyFromBeacon(beacon, (now + 181) * 1000), undefined)
+    assert.equal(beaconIsFresh(beacon, (now - 31) * 1000), false)
+  })
+})
+
+describe('enroll event', () => {
+  it('is kind 21004 with empty-object payload tags', () => {
+    const event = newNenrollEvent('{}', 'aa'.repeat(32), 'bb'.repeat(32))
+    assert.equal(event.kind, CLINK_ENROLL_KIND)
+    assert.deepEqual(event.tags, [['p', 'bb'.repeat(32)], ['clink_version', CLINK_VERSION]])
+  })
+})
+
+describe('fromNprofile', () => {
+  it('sets relays and service pubkey', () => {
+    const nprofile = 'nprofile1qy08wumn8ghj7ar9wd6z6un9d3shjtnvd9nksarwd9hxwtnsw43qqg8rqmz9ac98cae9grcaez9spaua95u3p075q3lfzpvynxx7nj0zhc7z748z'
+    const sdk = ClinkSDK.fromNprofile(nprofile, generateSecretKey())
+    assert.deepEqual(sdk.settings.relays, ['wss://test-relay.lightning.pub'])
+    assert.equal(sdk.settings.toPubKey, 'e306c45ee0a7c772540f1dc88b00f79d2d3910bfd4047e910584998de9c9e2be')
+    sdk.Stop()
+  })
+
+  it('rejects non-nprofile bech32', () => {
+    const npub = nip19.npubEncode('00'.repeat(32))
+    assert.throws(() => ClinkSDK.fromNprofile(npub, generateSecretKey()))
+  })
+})
+
+describe('enroll remine', () => {
+  it('probes then remine once on GFY 5', async () => {
+    const clientPriv = generateSecretKey()
+    const clientPub = getPublicKey(clientPriv)
+    const serverPriv = generateSecretKey()
+    const serverPub = getPublicKey(serverPriv)
+    const published = []
+    let onevent = null
+    const pool = {
+      subscribeMany(_relays, _filters, opts) {
+        onevent = opts.onevent
+        return { close: () => {} }
+      },
+      publish(_relays, event) {
+        published.push(event)
+        const gfy = published.length === 1
+        const payload = gfy
+          ? { res: 'GFY', code: 5, error: 'Insufficient proof of work', required_difficulty: 8 }
+          : { res: 'ok', noffer: 'noffer1x', ndebit: 'ndebit1x', nmanage: 'nmanage1x' }
+        const reply = {
+          id: `reply-${published.length}`,
+          kind: CLINK_ENROLL_KIND,
+          pubkey: serverPub,
+          content: encrypt(JSON.stringify(payload), getConversationKey(serverPriv, clientPub)),
+        }
+        queueMicrotask(() => onevent(reply))
+        return [Promise.resolve('ok')]
+      },
+    }
+    const res = await SendNenrollRequest(pool, clientPriv, ['wss://relay.example'], serverPub, 0, 5)
+    assert.equal(res.res, 'ok')
+    assert.equal(published.length, 2)
+    assert.equal(published[0].tags.some(t => t[0] === 'nonce'), false)
+    const nonce = published[1].tags.find(t => t[0] === 'nonce')
+    assert.equal(nonce[2], '8')
+    assert.ok(countLeadingZeroBits(published[1].id) >= 8)
+  })
+})

--- a/test/unit/enroll-beacon.test.mjs
+++ b/test/unit/enroll-beacon.test.mjs
@@ -16,6 +16,7 @@ import {
   CLINK_BEACON_D_TAG,
   CLINK_VERSION,
   ClinkSDK,
+  MAX_ENROLL_POW_BITS,
 } from '../../build/index.js'
 
 const { getConversationKey, encrypt } = nip44
@@ -42,6 +43,12 @@ describe('nip13 mining', () => {
     const event = newNenrollEvent('{}', 'ab'.repeat(32), 'cd'.repeat(32))
     assert.equal(mineNip13(event, 0), event)
     assert.equal(event.tags.some(t => t[0] === 'nonce'), false)
+  })
+
+  it('refuses to mine above the client cap', () => {
+    const event = newNenrollEvent('{}', 'ab'.repeat(32), 'cd'.repeat(32))
+    assert.throws(() => mineNip13(event, MAX_ENROLL_POW_BITS + 1))
+    assert.throws(() => mineNip13(event, 64))
   })
 })
 
@@ -106,6 +113,15 @@ describe('beacon parse', () => {
     assert.equal(enrollDifficultyFromBeacon(beacon, now * 1000), 18)
     assert.equal(enrollDifficultyFromBeacon(beacon, (now + 181) * 1000), undefined)
     assert.equal(beaconIsFresh(beacon, (now - 31) * 1000), false)
+  })
+
+  it('keeps huge enroll_difficulty for display but will not mine it', () => {
+    const beacon = parseClinkBeaconEvent(signBeacon({
+      content: JSON.stringify({ enroll_difficulty: 64 }),
+    }))
+    assert.ok(beacon)
+    assert.equal(beacon.content.enroll_difficulty, 64)
+    assert.equal(enrollDifficultyFromBeacon(beacon, now * 1000), undefined)
   })
 
   it('ignores unsigned relay spoofs when fetching', async () => {
@@ -198,5 +214,56 @@ describe('enroll remine', () => {
     const nonce = published[1].tags.find(t => t[0] === 'nonce')
     assert.equal(nonce[2], '8')
     assert.ok(countLeadingZeroBits(published[1].id) >= 8)
+  })
+
+  it('does not remine when GFY 5 asks above the client cap', async () => {
+    const clientPriv = generateSecretKey()
+    const clientPub = getPublicKey(clientPriv)
+    const serverPriv = generateSecretKey()
+    const serverPub = getPublicKey(serverPriv)
+    const published = []
+    let onevent = null
+    const pool = {
+      subscribeMany(_relays, _filters, opts) {
+        onevent = opts.onevent
+        return { close: () => {} }
+      },
+      publish(_relays, event) {
+        published.push(event)
+        const reply = {
+          id: `reply-${published.length}`,
+          kind: CLINK_ENROLL_KIND,
+          pubkey: serverPub,
+          content: encrypt(JSON.stringify({
+            res: 'GFY',
+            code: 5,
+            error: 'Insufficient proof of work',
+            required_difficulty: 64,
+          }), getConversationKey(serverPriv, clientPub)),
+        }
+        queueMicrotask(() => onevent(reply))
+        return [Promise.resolve('ok')]
+      },
+    }
+    const res = await SendNenrollRequest(pool, clientPriv, ['wss://relay.example'], serverPub, 0, 5)
+    assert.equal(res.res, 'GFY')
+    assert.equal(res.code, 5)
+    assert.equal(res.required_difficulty, 64)
+    assert.equal(published.length, 1)
+  })
+
+  it('throws before mining when caller asks above the client cap', async () => {
+    const published = []
+    const pool = {
+      subscribeMany() { return { close: () => {} } },
+      publish(_relays, event) {
+        published.push(event)
+        return [Promise.resolve('ok')]
+      },
+    }
+    await assert.rejects(
+      () => SendNenrollRequest(pool, generateSecretKey(), ['wss://relay.example'], 'cd'.repeat(32), 64, 5),
+    )
+    assert.equal(published.length, 0)
   })
 })

--- a/test/unit/sender.test.mjs
+++ b/test/unit/sender.test.mjs
@@ -2,6 +2,7 @@ import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
 import { generateSecretKey, getPublicKey, nip44 } from 'nostr-tools'
 import { sendRequest, setDebug } from '../../build/sender.js'
+import { signedClinkReply } from './signed-reply.mjs'
 
 const { getConversationKey, encrypt } = nip44
 
@@ -18,10 +19,6 @@ async function captureConsole(fn) {
     console.error = originalError
   }
   return lines
-}
-
-function makeEncryptedReply(serverPriv, clientPub, payload) {
-  return encrypt(JSON.stringify(payload), getConversationKey(serverPriv, clientPub))
 }
 
 function createMockPool({ onSubscribe, onPublish, replyFactory }) {
@@ -61,6 +58,26 @@ function createMockPool({ onSubscribe, onPublish, replyFactory }) {
   }
 }
 
+const requestEvent = (clientPub, serverPub) => ({
+  kind: 21001,
+  created_at: Math.floor(Date.now() / 1000),
+  tags: [['p', serverPub]],
+  content: 'unused',
+  pubkey: clientPub,
+})
+
+const sendOffer = (pool, clientPriv, clientPub, serverPub, timeoutSeconds = 5, moreCb) =>
+  sendRequest(
+    pool,
+    { privateKey: clientPriv, publicKey: clientPub },
+    ['wss://relay.example.com'],
+    serverPub,
+    requestEvent(clientPub, serverPub),
+    21001,
+    timeoutSeconds,
+    moreCb,
+  )
+
 describe('sender lifecycle', () => {
   it('subscribes before publish and resolves primary response', async () => {
     const clientPriv = generateSecretKey()
@@ -69,31 +86,12 @@ describe('sender lifecycle', () => {
     const serverPub = getPublicKey(serverPriv)
 
     const pool = createMockPool({
-      replyFactory: () => [
-        {
-          id: 'reply1',
-          kind: 21001,
-          pubkey: serverPub,
-          content: makeEncryptedReply(serverPriv, clientPub, { bolt11: 'lnbc1dummy' }),
-        },
+      replyFactory: (request) => [
+        signedClinkReply(serverPriv, clientPub, request.id, { bolt11: 'lnbc1dummy' }, 21001),
       ],
     })
 
-    const result = await sendRequest(
-      pool,
-      { privateKey: clientPriv, publicKey: clientPub },
-      ['wss://relay.example.com'],
-      serverPub,
-      {
-        kind: 21001,
-        created_at: Math.floor(Date.now() / 1000),
-        tags: [['p', serverPub]],
-        content: 'unused',
-        pubkey: clientPub,
-      },
-      21001,
-      5
-    )
+    const result = await sendOffer(pool, clientPriv, clientPub, serverPub)
 
     assert.deepEqual(result, { bolt11: 'lnbc1dummy' })
     assert.deepEqual(pool.order.slice(0, 2), ['subscribe', 'publish'])
@@ -107,88 +105,48 @@ describe('sender lifecycle', () => {
     const serverPub = getPublicKey(serverPriv)
 
     let onevent = null
+    let requestId = null
     const pool = createMockPool({
       onSubscribe: (_r, _f, opts) => {
         onevent = opts.onevent
       },
-      replyFactory: () => [
-        {
-          id: 'primary',
-          kind: 21001,
-          pubkey: serverPub,
-          content: makeEncryptedReply(serverPriv, clientPub, { bolt11: 'lnbc1dummy' }),
-        },
-      ],
+      replyFactory: (request) => {
+        requestId = request.id
+        return [signedClinkReply(serverPriv, clientPub, request.id, { bolt11: 'lnbc1dummy' }, 21001)]
+      },
     })
 
     let receipt = null
-    const primary = await sendRequest(
-      pool,
-      { privateKey: clientPriv, publicKey: clientPub },
-      ['wss://relay.example.com'],
-      serverPub,
-      {
-        kind: 21001,
-        created_at: Math.floor(Date.now() / 1000),
-        tags: [['p', serverPub]],
-        content: 'unused',
-        pubkey: clientPub,
-      },
-      21001,
-      5,
-      (data) => {
-        receipt = data
-      }
-    )
+    const primary = await sendOffer(pool, clientPriv, clientPub, serverPub, 5, (data) => {
+      receipt = data
+    })
 
     assert.deepEqual(primary, { bolt11: 'lnbc1dummy' })
     assert.equal(pool.wasClosed(), false)
 
-    await onevent({
-      id: 'receipt',
-      kind: 21001,
-      pubkey: serverPub,
-      content: makeEncryptedReply(serverPriv, clientPub, { res: 'ok' }),
-    })
+    await onevent(signedClinkReply(serverPriv, clientPub, requestId, { res: 'ok' }, 21001))
 
     assert.deepEqual(receipt, { res: 'ok' })
     assert.equal(pool.wasClosed(), true)
   })
 
-  it('rejects on decrypt failure from expected peer', async () => {
+  it('rejects on decrypt failure from a verified peer reply', async () => {
     const clientPriv = generateSecretKey()
     const clientPub = getPublicKey(clientPriv)
-    const serverPub = getPublicKey(generateSecretKey())
+    const serverPriv = generateSecretKey()
+    const serverPub = getPublicKey(serverPriv)
     const otherPriv = generateSecretKey()
 
     const pool = createMockPool({
-      replyFactory: () => [
-        {
-          id: 'bad',
-          kind: 21001,
-          pubkey: serverPub,
-          content: makeEncryptedReply(otherPriv, clientPub, { bolt11: 'nope' }),
-        },
+      replyFactory: (request) => [
+        signedClinkReply(serverPriv, clientPub, request.id, { bolt11: 'nope' }, 21001, {
+          content: encrypt(JSON.stringify({ bolt11: 'nope' }), getConversationKey(otherPriv, clientPub)),
+        }),
       ],
     })
 
     await assert.rejects(
-      () =>
-        sendRequest(
-          pool,
-          { privateKey: clientPriv, publicKey: clientPub },
-          ['wss://relay.example.com'],
-          serverPub,
-          {
-            kind: 21001,
-            created_at: Math.floor(Date.now() / 1000),
-            tags: [['p', serverPub]],
-            content: 'unused',
-            pubkey: clientPub,
-          },
-          21001,
-          5
-        ),
+      () => sendOffer(pool, clientPriv, clientPub, serverPub),
       /./
     )
     assert.equal(pool.wasClosed(), true)
@@ -203,40 +161,76 @@ describe('sender lifecycle', () => {
     const attackerPub = getPublicKey(attackerPriv)
 
     const pool = createMockPool({
-      replyFactory: () => [
-        {
-          id: 'forged',
-          kind: 21001,
-          pubkey: attackerPub,
-          content: 'not-valid-nip44',
-        },
-        {
-          id: 'reply1',
-          kind: 21001,
-          pubkey: serverPub,
-          content: makeEncryptedReply(serverPriv, clientPub, { bolt11: 'lnbc1dummy' }),
-        },
+      replyFactory: (request) => [
+        signedClinkReply(attackerPriv, clientPub, request.id, { bolt11: 'stolen' }, 21001),
+        signedClinkReply(serverPriv, clientPub, request.id, { bolt11: 'lnbc1dummy' }, 21001),
       ],
     })
 
-    const result = await sendRequest(
-      pool,
-      { privateKey: clientPriv, publicKey: clientPub },
-      ['wss://relay.example.com'],
-      serverPub,
-      {
-        kind: 21001,
-        created_at: Math.floor(Date.now() / 1000),
-        tags: [['p', serverPub]],
-        content: 'unused',
-        pubkey: clientPub,
-      },
-      21001,
-      5
-    )
+    const result = await sendOffer(pool, clientPriv, clientPub, serverPub)
 
     assert.deepEqual(result, { bolt11: 'lnbc1dummy' })
     assert.equal(pool.wasClosed(), true)
+  })
+
+  it('ignores an unsigned spoof that copies a real ciphertext', async () => {
+    const clientPriv = generateSecretKey()
+    const clientPub = getPublicKey(clientPriv)
+    const serverPriv = generateSecretKey()
+    const serverPub = getPublicKey(serverPriv)
+
+    const pool = createMockPool({
+      replyFactory: (request) => {
+        const real = signedClinkReply(serverPriv, clientPub, request.id, { bolt11: 'lnbc1dummy' }, 21001)
+        const spoof = {
+          kind: real.kind,
+          pubkey: real.pubkey,
+          created_at: real.created_at,
+          tags: real.tags,
+          content: encrypt(JSON.stringify({ bolt11: 'stolen' }), getConversationKey(serverPriv, clientPub)),
+          id: '11'.repeat(32),
+          sig: '11'.repeat(64),
+        }
+        return [spoof, real]
+      },
+    })
+
+    const result = await sendOffer(pool, clientPriv, clientPub, serverPub)
+    assert.deepEqual(result, { bolt11: 'lnbc1dummy' })
+  })
+
+  it('ignores a signed reply tagged to a different request', async () => {
+    const clientPriv = generateSecretKey()
+    const clientPub = getPublicKey(clientPriv)
+    const serverPriv = generateSecretKey()
+    const serverPub = getPublicKey(serverPriv)
+
+    const pool = createMockPool({
+      replyFactory: (request) => [
+        signedClinkReply(serverPriv, clientPub, '00'.repeat(32), { bolt11: 'replay' }, 21001),
+        signedClinkReply(serverPriv, clientPub, request.id, { bolt11: 'lnbc1dummy' }, 21001),
+      ],
+    })
+
+    const result = await sendOffer(pool, clientPriv, clientPub, serverPub)
+    assert.deepEqual(result, { bolt11: 'lnbc1dummy' })
+  })
+
+  it('ignores a signed reply with an unsupported clink_version', async () => {
+    const clientPriv = generateSecretKey()
+    const clientPub = getPublicKey(clientPriv)
+    const serverPriv = generateSecretKey()
+    const serverPub = getPublicKey(serverPriv)
+
+    const pool = createMockPool({
+      replyFactory: (request) => [
+        signedClinkReply(serverPriv, clientPub, request.id, { bolt11: 'v2' }, 21001, { clinkVersion: '2' }),
+        signedClinkReply(serverPriv, clientPub, request.id, { bolt11: 'lnbc1dummy' }, 21001),
+      ],
+    })
+
+    const result = await sendOffer(pool, clientPriv, clientPub, serverPub)
+    assert.deepEqual(result, { bolt11: 'lnbc1dummy' })
   })
 
   it('matches peer pubkey case-insensitively', async () => {
@@ -246,32 +240,12 @@ describe('sender lifecycle', () => {
     const serverPub = getPublicKey(serverPriv)
 
     const pool = createMockPool({
-      replyFactory: () => [
-        {
-          id: 'reply1',
-          kind: 21001,
-          pubkey: serverPub,
-          content: makeEncryptedReply(serverPriv, clientPub, { bolt11: 'lnbc1dummy' }),
-        },
+      replyFactory: (request) => [
+        signedClinkReply(serverPriv, clientPub, request.id, { bolt11: 'lnbc1dummy' }, 21001),
       ],
     })
 
-    const result = await sendRequest(
-      pool,
-      { privateKey: clientPriv, publicKey: clientPub },
-      ['wss://relay.example.com'],
-      serverPub.toUpperCase(),
-      {
-        kind: 21001,
-        created_at: Math.floor(Date.now() / 1000),
-        tags: [['p', serverPub]],
-        content: 'unused',
-        pubkey: clientPub,
-      },
-      21001,
-      5
-    )
-
+    const result = await sendOffer(pool, clientPriv, clientPub, serverPub.toUpperCase())
     assert.deepEqual(result, { bolt11: 'lnbc1dummy' })
     assert.equal(pool.wasClosed(), true)
   })
@@ -286,22 +260,7 @@ describe('sender lifecycle', () => {
     })
 
     await assert.rejects(
-      () =>
-        sendRequest(
-          pool,
-          { privateKey: clientPriv, publicKey: clientPub },
-          ['wss://relay.example.com'],
-          serverPub,
-          {
-            kind: 21001,
-            created_at: Math.floor(Date.now() / 1000),
-            tags: [['p', serverPub]],
-            content: 'unused',
-            pubkey: clientPub,
-          },
-          21001,
-          0.05
-        ),
+      () => sendOffer(pool, clientPriv, clientPub, serverPub, 0.05),
       /failed to get response in time/
     )
     assert.equal(pool.wasClosed(), true)
@@ -312,23 +271,14 @@ describe('debug logging', () => {
   const clientPriv = generateSecretKey()
   const clientPub = getPublicKey(clientPriv)
   const serverPub = getPublicKey(generateSecretKey())
-  const request = {
-    kind: 21001,
-    created_at: Math.floor(Date.now() / 1000),
-    tags: [['p', serverPub]],
-    content: 'unused',
-    pubkey: clientPub,
-  }
 
   const sendAndTimeout = () =>
-    sendRequest(
+    sendOffer(
       createMockPool({ replyFactory: () => [] }),
-      { privateKey: clientPriv, publicKey: clientPub },
-      ['wss://relay.example.com'],
+      clientPriv,
+      clientPub,
       serverPub,
-      request,
-      21001,
-      0.05
+      0.05,
     ).catch(() => {})
 
   it('is silent by default', async () => {

--- a/test/unit/signed-reply.mjs
+++ b/test/unit/signed-reply.mjs
@@ -1,0 +1,15 @@
+import { finalizeEvent, nip44 } from 'nostr-tools'
+
+const { getConversationKey, encrypt } = nip44
+
+export const signedClinkReply = (serverPriv, clientPub, requestId, payload, kind, extra = {}) =>
+  finalizeEvent({
+    kind,
+    created_at: Math.floor(Date.now() / 1000),
+    tags: [
+      ['p', extra.p ?? clientPub],
+      ['e', extra.e ?? requestId],
+      ['clink_version', extra.clinkVersion ?? '1'],
+    ],
+    content: extra.content ?? encrypt(JSON.stringify(payload), getConversationKey(serverPriv, clientPub)),
+  }, serverPriv)


### PR DESCRIPTION
## Summary
- Add `Nenroll` / `SendNenrollRequest` (kind 21004): bind a signing key to an account and return that account's `noffer` / `ndebit` / `nmanage`.
- Add `Nbeacon` / `FetchClinkBeacon`: fetch the latest kind `30078` `d=clink-node` event for liveness, persona, fees, and advertised kinds.
- Enroll mines NIP-13 when needed: omitted `difficulty` uses a fresh beacon's `enroll_difficulty`, otherwise probes and remine once on GFY `5`.
- `ClinkSDK.fromNprofile` builds settings from an `nprofile` (service pubkey + relays). Package bump to `1.7.0`.

Beacon parse is CLINK-only (`d=clink-node` + `clink_version`). Legacy `d=Lightning.Pub` is ignored. Operator attestation / explorer verification is out of scope — this only reads the service's optional `operator` tag.

`Nenroll()` returns the final enroll result. A probe GFY `5` is handled inside `SendNenrollRequest` (remine once) and is not surfaced to the caller.

## Test plan
`npm test`: 34 pass, 0 fail.

Live against `nprofile1qy08wumn8ghj7ar9wd6z6un9d3shjtnvd9nksarwd9hxwtnsw43qqg8rqmz9ac98cae9grcaez9spaua95u3p075q3lfzpvynxx7nj0zhc7z748z` (`wss://test-relay.lightning.pub` / `wallet-test`):

- `fromNprofile` resolved relay + service pubkey
- `Nbeacon()` returned a fresh `clink-node` beacon (`enroll_difficulty` 18, kinds 21001–21004, fees 100/60)
- `Nenroll()` with no args used the beacon fast-path, mined 18 locally, returned `ok` + decodeable `noffer` / `ndebit` / `nmanage` (no client-visible GFY)
- `Nenroll({ difficulty: 0 })` probed: first 21004 had no `nonce`, Pub challenged 18, second 21004 had `nonce` target 18, then `ok`. Caller still only saw `ok`.
- `Noffer({ amount_sats: 21 })` on the enrolled offer returned a `bolt11`